### PR TITLE
file system system calls property test and minor bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,12 +743,15 @@ dependencies = [
 name = "init"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "cstr_core",
+ "hashbrown 0.11.2",
  "kpi",
  "lazy_static",
  "libm",
  "lineup",
  "log",
+ "proptest",
  "rawtime",
  "spin 0.5.2",
  "vibrio",
@@ -1172,6 +1175,7 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+ "x86 0.33.0",
 ]
 
 [[package]]
@@ -1331,6 +1335,17 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9c0f2091b865a94bc3c9d34896cc4bbda04453453c391f7eb224491be9ae1d"
+dependencies = [
+ "bitflags",
+ "cc",
+ "rustc_version",
+]
+
+[[package]]
+name = "raw-cpuid"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
@@ -1437,6 +1452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1483,21 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1791,13 +1830,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x86"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2786ac694ed572ab5d2bbcd9e188805dba26b3501973dd69718914fb3d4a5a69"
+dependencies = [
+ "bit_field",
+ "bitflags",
+ "raw-cpuid 8.0.0",
+]
+
+[[package]]
+name = "x86"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fd9298cd1b1f88546fc0a5e8faa3354013cd010589299c624fde436aad76cc"
 dependencies = [
  "bit_field",
  "bitflags",
- "raw-cpuid",
+ "raw-cpuid 9.0.0",
 ]
 
 [[package]]
@@ -1808,7 +1858,7 @@ checksum = "702d51a8a099ea6b47826796377591d2ed47116c7f0454f0d08d1d9872944880"
 dependencies = [
  "bit_field",
  "bitflags",
- "raw-cpuid",
+ "raw-cpuid 9.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +744,7 @@ name = "init"
 version = "0.1.0"
 dependencies = [
  "cstr_core",
+ "kpi",
  "lazy_static",
  "libm",
  "lineup",
@@ -975,7 +989,7 @@ dependencies = [
  "ctor",
  "driverkit",
  "elfloader",
- "env_logger 0.8.3",
+ "env_logger 0.9.0",
  "fallible_collections",
  "gimli 0.24.0",
  "hashbrown 0.11.2",
@@ -1698,7 +1712,7 @@ dependencies = [
  "arrayvec",
  "custom_error",
  "driverkit",
- "env_logger 0.8.3",
+ "env_logger 0.9.0",
  "log",
  "smoltcp",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,7 +755,6 @@ dependencies = [
  "arrayvec",
  "cstr_core",
  "hashbrown 0.11.2",
- "kpi",
  "lazy_static",
  "libm",
  "lineup",
@@ -792,7 +800,7 @@ name = "kpi"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "env_logger 0.8.3",
+ "env_logger 0.9.0",
  "log",
  "serde",
  "serde_cbor",
@@ -842,7 +850,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils 0.8.5",
  "either",
- "env_logger 0.8.3",
+ "env_logger 0.9.0",
  "fringe",
  "hashbrown 0.11.2",
  "kpi",
@@ -994,7 +1002,7 @@ dependencies = [
  "elfloader",
  "env_logger 0.9.0",
  "fallible_collections",
- "gimli 0.24.0",
+ "gimli 0.25.0",
  "hashbrown 0.11.2",
  "hwloc2",
  "klogger",

--- a/kernel/src/arch/x86_64/process.rs
+++ b/kernel/src/arch/x86_64/process.rs
@@ -1182,10 +1182,14 @@ impl Process for Ring3Process {
 
     fn deallocate_fd(&mut self, fd: usize) -> Result<usize, KError> {
         match self.fds.get_mut(fd) {
-            Some(fdinfo) => {
-                *fdinfo = None;
-                Ok(fd)
-            }
+            Some(fdinfo) => match fdinfo {
+                Some(info) => {
+                    log::debug!("deallocating: {:?}", info);
+                    *fdinfo = None;
+                    Ok(fd)
+                }
+                None => Err(KError::InvalidFileDescriptor),
+            },
             None => Err(KError::InvalidFileDescriptor),
         }
     }

--- a/kernel/src/cnrfs.rs
+++ b/kernel/src/cnrfs.rs
@@ -475,8 +475,11 @@ impl Dispatch for MlnrKernelNode {
                 if let Some(mnode) = mnode {
                     // File exists and FileOpen is called with O_TRUNC flag.
                     if flags.is_truncate() {
-                        // Truncate may fail if file modes is not readable
-                        self.fs.truncate(&filename)?;
+                        if let Err(e) = self.fs.truncate(&filename) {
+                            let fdesc = fid as usize;
+                            pmap.get_mut(&pid).unwrap().deallocate_fd(fdesc)?;
+                            return Err(e);
+                        }
                     }
                     mnode_num = *mnode;
                 } else {

--- a/kernel/src/cnrfs.rs
+++ b/kernel/src/cnrfs.rs
@@ -475,7 +475,8 @@ impl Dispatch for MlnrKernelNode {
                 if let Some(mnode) = mnode {
                     // File exists and FileOpen is called with O_TRUNC flag.
                     if flags.is_truncate() {
-                        assert!(self.fs.truncate(&filename).is_ok());
+                        // Truncate may fail if file modes is not readable
+                        self.fs.truncate(&filename)?;
                     }
                     mnode_num = *mnode;
                 } else {

--- a/kernel/src/fs/fd.rs
+++ b/kernel/src/fs/fd.rs
@@ -31,7 +31,6 @@ impl FileDesc {
         match self.fds.get_mut(fd) {
             Some(fdinfo) => match fdinfo {
                 Some(info) => {
-                    log::debug!("deallocating: {:?}", info);
                     *fdinfo = None;
                     Ok(fd)
                 }

--- a/kernel/src/fs/fd.rs
+++ b/kernel/src/fs/fd.rs
@@ -29,10 +29,14 @@ impl FileDesc {
 
     pub fn deallocate_fd(&mut self, fd: usize) -> Result<usize, KError> {
         match self.fds.get_mut(fd) {
-            Some(fdinfo) => {
-                *fdinfo = None;
-                Ok(fd)
-            }
+            Some(fdinfo) => match fdinfo {
+                Some(info) => {
+                    log::debug!("deallocating: {:?}", info);
+                    *fdinfo = None;
+                    Ok(fd)
+                }
+                None => Err(KError::InvalidFileDescriptor),
+            },
             None => Err(KError::InvalidFileDescriptor),
         }
     }

--- a/kernel/src/fs/fd.rs
+++ b/kernel/src/fs/fd.rs
@@ -30,7 +30,7 @@ impl FileDesc {
     pub fn deallocate_fd(&mut self, fd: usize) -> Result<usize, KError> {
         match self.fds.get_mut(fd) {
             Some(fdinfo) => match fdinfo {
-                Some(info) => {
+                Some(_info) => {
                     *fdinfo = None;
                     Ok(fd)
                 }

--- a/kernel/tests/integration-test.rs
+++ b/kernel/tests/integration-test.rs
@@ -1958,8 +1958,9 @@ fn s06_test_fs() {
 ///  * File read, write
 ///  * File getinfo
 #[test]
+#[ignore = "always fails, seems to be bug in cnrfs?"]
 fn s06_test_fs_prop() {
-    let cmdline = RunnerArgs::new("test-userspace-smp")
+    let cmdline = RunnerArgs::new("test-userspace")
         .module("init")
         .user_feature("test-fs-prop")
         .release()

--- a/kernel/tests/integration-test.rs
+++ b/kernel/tests/integration-test.rs
@@ -1951,6 +1951,32 @@ fn s06_test_fs() {
     check_for_successful_exit(&cmdline, qemu_run(), output);
 }
 
+/// Property tests for file-system support.
+///
+/// This tests various file-system systemcalls such as:
+///  * File open, close
+///  * File read, write
+///  * File getinfo
+#[test]
+fn s06_test_fs_prop() {
+    let cmdline = RunnerArgs::new("test-userspace-smp")
+        .module("init")
+        .user_feature("test-fs-prop")
+        .release()
+        .timeout(20_000);
+    let mut output = String::new();
+
+    let mut qemu_run = || -> Result<WaitStatus> {
+        let mut p = spawn_nrk(&cmdline)?;
+
+        p.exp_string("fs_prop_test OK")?;
+        output = p.exp_eof()?;
+        p.process.exit()
+    };
+
+    check_for_successful_exit(&cmdline, qemu_run(), output);
+}
+
 fn memcached_benchmark(
     driver: &'static str,
     cores: usize,

--- a/kernel/tests/integration-test.rs
+++ b/kernel/tests/integration-test.rs
@@ -1958,13 +1958,12 @@ fn s06_test_fs() {
 ///  * File read, write
 ///  * File getinfo
 #[test]
-#[ignore = "always fails, seems to be bug in cnrfs?"]
 fn s06_test_fs_prop() {
     let cmdline = RunnerArgs::new("test-userspace")
         .module("init")
         .user_feature("test-fs-prop")
         .release()
-        .timeout(20_000);
+        .timeout(120_000);
     let mut output = String::new();
 
     let mut qemu_run = || -> Result<WaitStatus> {

--- a/lib/vibrio/src/lib.rs
+++ b/lib/vibrio/src/lib.rs
@@ -18,7 +18,7 @@
 extern crate alloc;
 extern crate kpi;
 
-pub use kpi::{io, syscalls};
+pub use kpi::*;
 
 extern crate arrayvec;
 extern crate lazy_static;

--- a/usr/init/Cargo.toml
+++ b/usr/init/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/init.rs"
 
 [dependencies]
 lineup = { path = "../../lib/lineup" }
+kpi = { path = "../../lib/kpi" }
 vibrio = { path = "../../lib/vibrio" }
 rawtime = "0.0.4"
 x86 = "0.40"

--- a/usr/init/Cargo.toml
+++ b/usr/init/Cargo.toml
@@ -18,9 +18,12 @@ rawtime = "0.0.4"
 x86 = "0.40"
 log = "0.4"
 libm = "0.2.1"
+arrayvec = { version = "0.7.0", default-features = false }
 lazy_static =  { version = "1.4", default_features = false }
 cstr_core = { version = "0.2.3", default-features = false }
 spin = { version = "0.5.2", default_features = false }
+hashbrown = { version = "0.11", features = [ "nightly" ] }
+proptest = {version = "1.0.0", default-features = false, features = ['alloc', 'hardware-rng']}
 
 [features]
 default = []
@@ -39,6 +42,7 @@ test-scheduler-smp = []
 test-rump-tmpfs = [ "rumprt" ]
 test-rump-net = [ "rumprt" ]
 test-fs = []
+test-fs-prop = []
 
 # Simple micro-benchmarks
 bench-vmops = []

--- a/usr/init/Cargo.toml
+++ b/usr/init/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/init.rs"
 
 [dependencies]
 lineup = { path = "../../lib/lineup" }
-kpi = { path = "../../lib/kpi" }
 vibrio = { path = "../../lib/vibrio" }
 rawtime = "0.0.4"
 x86 = "0.40"

--- a/usr/init/src/fs.rs
+++ b/usr/init/src/fs.rs
@@ -9,13 +9,775 @@ use core::cell::RefCell;
 use core::cmp::{Eq, PartialEq};
 use core::slice::{from_raw_parts, from_raw_parts_mut};
 use core::sync::atomic::{AtomicUsize, Ordering};
+use cstr_core::CStr;
+use hashbrown::HashMap;
 
 use crate::alloc::borrow::ToOwned;
 
 use kpi::io::*;
 use kpi::SystemCallError;
+use x86::bits64::paging::{PAddr, VAddr};
 
 use log::trace;
+use proptest::prelude::*;
+
+pub type Mnode = u64;
+
+const MAX_FILES_PER_PROCESS: usize = 4096;
+
+pub fn userptr_to_str(useraddr: u64) -> Result<String, SystemCallError> {
+    let user_ptr = VAddr::from(useraddr);
+    unsafe {
+        match CStr::from_ptr(user_ptr.as_ptr()).to_str() {
+            Ok(path) => Ok(path.to_string()),
+            Err(_) => Err(SystemCallError::NotSupported),
+        }
+    }
+}
+
+/// What operations that the model needs to keep track of.
+///
+/// We don't need to log reads or lookups.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ModelOperation {
+    /// Stores a write to an mnode, at given offset, pattern, length.
+    Write(Mnode, i64, char, u64),
+    /// Stores info about created files.
+    Created(String, FileModes, Mnode),
+}
+
+/// A file descriptor representaion.
+#[derive(Debug, Default)]
+struct Fd {
+    mnode: Mnode,
+    flags: FileFlags,
+    offset: AtomicUsize,
+}
+
+impl Fd {
+    fn init_fd() -> Fd {
+        Fd {
+            // Intial values are just the place-holders and shouldn't be used.
+            mnode: u64::MAX,
+            flags: Default::default(),
+            offset: AtomicUsize::new(0),
+        }
+    }
+
+    fn update_fd(&mut self, mnode: Mnode, flags: FileFlags) {
+        self.mnode = mnode;
+        self.flags = flags;
+    }
+
+    fn get_mnode(&self) -> Mnode {
+        self.mnode
+    }
+
+    fn get_flags(&self) -> FileFlags {
+        self.flags
+    }
+
+    fn get_offset(&self) -> usize {
+        self.offset.load(Ordering::Relaxed)
+    }
+
+    fn update_offset(&self, new_offset: usize) {
+        self.offset.store(new_offset, Ordering::Release);
+    }
+}
+
+pub struct FileDesc {
+    fds: arrayvec::ArrayVec<Option<Fd>, MAX_FILES_PER_PROCESS>,
+}
+
+impl Default for FileDesc {
+    fn default() -> Self {
+        const NONE_FD: Option<Fd> = None;
+        FileDesc {
+            fds: arrayvec::ArrayVec::from([NONE_FD; MAX_FILES_PER_PROCESS]),
+        }
+    }
+}
+
+impl FileDesc {
+    pub fn allocate_fd(&mut self) -> Result<(u64, &mut Fd), SystemCallError> {
+        if let Some(fid) = self.fds.iter().position(|fd| fd.is_none()) {
+            self.fds[fid] = Some(Default::default());
+            Ok((fid as u64, self.fds[fid as usize].as_mut().unwrap()))
+        } else {
+            Err(SystemCallError::InternalError)
+        }
+    }
+
+    pub fn deallocate_fd(&mut self, fd: u64) -> Result<u64, SystemCallError> {
+        match self.fds.get_mut(fd as usize) {
+            Some(fdinfo) => {
+                *fdinfo = None;
+                Ok(fd)
+            }
+            None => Err(SystemCallError::InternalError),
+        }
+    }
+
+    pub fn get_fd(&self, index: usize) -> Result<&Fd, SystemCallError> {
+        if let Some(fd) = self.fds[index].as_ref() {
+            Ok(fd)
+        } else {
+            Err(SystemCallError::InternalError)
+        }
+    }
+
+    pub fn find_fd(&self, mnode: Mnode) -> Option<u64> {
+        if let Some(fid) = self.fds.iter().position(|fd_pos| {
+            if let Some(fd) = &&fd_pos {
+                fd.get_mnode() == mnode
+            } else {
+                false
+            }
+        }) {
+            Some(fid as u64)
+        } else {
+            None
+        }
+    }
+}
+
+/// The FS model that we strive to implement.
+struct ModelFIO {
+    /// A log that stores all operations on the model FS.
+    oplog: RefCell<Vec<ModelOperation>>,
+    /// A counter to hand out mnode identifiers.
+    mnode_counter: RefCell<u64>,
+    /// File descriptors
+    fds: FileDesc,
+}
+
+impl Default for ModelFIO {
+    fn default() -> Self {
+        let oplog = RefCell::new(Vec::with_capacity(64));
+        oplog
+            .borrow_mut()
+            .push(ModelOperation::Created("/".to_string(), 0.into(), 1));
+        ModelFIO {
+            oplog,
+            mnode_counter: RefCell::new(1),
+            fds: Default::default(),
+        }
+    }
+}
+
+impl ModelFIO {
+    /// Find mnode of a path.
+    fn path_to_mnode(&self, path: &String) -> Option<Mnode> {
+        for x in self.oplog.borrow().iter().rev() {
+            match x {
+                ModelOperation::Created(name, _mode, mnode) => {
+                    if &name == &path {
+                        return Some(*mnode);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+
+    /// Find index of a path in the oplog.
+    fn path_to_idx(&self, path: &String) -> Option<usize> {
+        for (idx, x) in self.oplog.borrow().iter().enumerate().rev() {
+            match x {
+                ModelOperation::Created(name, _mode, _mnode) => {
+                    if &name == &path {
+                        return Some(idx);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+
+    /// Check if a given path exists.
+    fn file_exists(&self, path: &String) -> bool {
+        self.path_to_mnode(path).is_some()
+    }
+
+    /// Check if a mnode exists.
+    fn mnode_exists(&self, look_for: Mnode) -> bool {
+        for x in self.oplog.borrow().iter().rev() {
+            match x {
+                ModelOperation::Created(_name, _mode, mnode) => {
+                    if look_for == *mnode {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        false
+    }
+
+    /// Checks if there is overlap between two ranges
+    fn overlaps<T: PartialOrd>(a: &core::ops::Range<T>, b: &core::ops::Range<T>) -> bool {
+        a.start < b.end && b.start < a.end
+    }
+
+    /// A very silly O(n) method that caculates the intersection between two ranges
+    fn intersection(
+        a: core::ops::Range<usize>,
+        b: core::ops::Range<usize>,
+    ) -> Option<core::ops::Range<usize>> {
+        if ModelFIO::overlaps(&a, &b) {
+            let mut min = usize::MAX;
+            let mut max = 0;
+
+            for element in a {
+                if b.contains(&element) {
+                    min = core::cmp::min(element, min);
+                    max = core::cmp::max(element, max);
+                }
+            }
+            Some(min..max + 1)
+        } else {
+            None
+        }
+    }
+
+    // Create just puts the file in the oplop and increases mnode counter.
+    pub fn open(&mut self, pathname: u64, flags: u64, modes: u64) -> Result<u64, SystemCallError> {
+        let path = userptr_to_str(pathname)?;
+        let flags = FileFlags::from(flags);
+
+        // If file exists, only create new fd
+        if let Some(mnode) = self.lookup(&path) {
+            if flags.is_create() {
+                Err(SystemCallError::InternalError)
+            } else {
+                let (fid, fd) = self.fds.allocate_fd()?;
+                fd.update_fd(*self.mnode_counter.borrow(), flags);
+
+                if flags.is_append() {
+                    // TODO: if append, set position to end of file
+                }
+                if flags.is_truncate() {
+                    // TODO: truncate length of file
+                }
+
+                Ok(fid)
+            }
+
+        // Create new file if necessary
+        } else {
+            if !flags.is_create() {
+                return Err(SystemCallError::InternalError);
+            }
+
+            *self.mnode_counter.borrow_mut() += 1;
+            self.oplog.borrow_mut().push(ModelOperation::Created(
+                path,
+                FileModes::from(modes),
+                *self.mnode_counter.borrow(),
+            ));
+            let (fid, fd) = self.fds.allocate_fd()?;
+            fd.update_fd(*self.mnode_counter.borrow(), flags);
+            Ok(fid)
+        }
+    }
+
+    pub fn write(&self, fid: u64, buffer: u64, len: u64) -> Result<u64, SystemCallError> {
+        // TODO: this seems wrong... should be InternalError??
+        if len == 0 {
+            return Err(SystemCallError::BadFileDescriptor);
+        }
+
+        let fd = self.fds.get_fd(fid as usize)?;
+        self.write_at(fid, buffer, len, fd.get_offset() as i64)
+    }
+
+    /// Write just logs the write to the oplog.
+    ///
+    /// Our model assumes that the buffer repeats the first byte for its entire length.
+    pub fn write_at(
+        &self,
+        fid: u64,
+        buffer: u64,
+        len: u64,
+        offset: i64,
+    ) -> Result<u64, SystemCallError> {
+        // TODO: this seems wrong... should be InternalError??
+        if len == 0 {
+            return Err(SystemCallError::BadFileDescriptor);
+        }
+
+        let mut fd = self.fds.get_fd(fid as usize)?;
+        let flags = fd.get_flags();
+
+        // check for write permissions
+        if !flags.is_write() {
+            return Err(SystemCallError::InternalError);
+        }
+
+        let mnode = fd.get_mnode();
+        if self.mnode_exists(mnode) {
+            for x in self.oplog.borrow().iter().rev() {
+                trace!("seen {:?}", x);
+                match x {
+                    // Check if the file is writable or not
+                    ModelOperation::Created(_path, mode, current_mnode) => {
+                        if mnode == *current_mnode && !FileModes::from(*mode).is_writable() {
+                            return Err(SystemCallError::InternalError);
+                        }
+                    }
+                    _ => { /* The operation is not relevant */ }
+                }
+            }
+
+            if len > 0 {
+                // Model assumes that buffer is filled with the same pattern all the way
+                let slice = unsafe { from_raw_parts(buffer as *const u8, 1) };
+                let pattern = slice[0] as char;
+                self.oplog
+                    .borrow_mut()
+                    .push(ModelOperation::Write(mnode, offset, pattern, len));
+            }
+            fd.update_offset(offset as usize + len as usize);
+            Ok(len)
+        } else {
+            Err(SystemCallError::InternalError)
+        }
+    }
+
+    pub fn read(&self, fid: u64, buffer: u64, len: u64) -> Result<u64, SystemCallError> {
+        // TODO: this seems wrong... should be InternalError??
+        if len == 0 {
+            return Err(SystemCallError::BadFileDescriptor);
+        }
+
+        let fd = self.fds.get_fd(fid as usize)?;
+        self.read_at(fid, buffer, len, fd.get_offset() as i64)
+    }
+
+    /// read loops through the oplog and tries to fill up the buffer by looking
+    /// at the logged `Write` ops.
+    ///
+    /// This is the hardest operation to represent in the model.
+    pub fn read_at(
+        &self,
+        fid: u64,
+        buffer: u64,
+        len: u64,
+        offset: i64,
+    ) -> Result<u64, SystemCallError> {
+        // TODO: this seems wrong, should be internal Error??
+        if len == 0 {
+            return Err(SystemCallError::BadFileDescriptor);
+        }
+
+        let fd = self.fds.get_fd(fid as usize)?;
+        let flags = fd.get_flags();
+
+        // check for read permissions
+        if !flags.is_read() {
+            return Err(SystemCallError::InternalError);
+        }
+
+        let mnode = fd.get_mnode();
+        if self.mnode_exists(mnode) {
+            // We store our 'retrieved' data in a buffer of Option<u8>
+            // to make sure in case we have consecutive writes to the same region
+            // we take the last one, and also to detect if we
+            // read more than what ever got written to the file...
+            let mut buffer_gatherer: Vec<Option<u8>> = Vec::with_capacity(len as usize);
+            for _i in 0..len {
+                buffer_gatherer.push(None);
+            }
+
+            // Start with the latest writes first
+            for x in self.oplog.borrow().iter().rev() {
+                trace!("seen {:?}", x);
+                match x {
+                    ModelOperation::Write(wmnode, foffset, fpattern, flength) => {
+                        // Write is for the correct file and the offset starts somewhere
+                        // in that write
+                        let cur_segment_range =
+                            *foffset as usize..(*foffset as usize + *flength as usize);
+                        let read_range = offset as usize..(offset as usize + len as usize);
+                        trace!("*wfd == fd = {}", *wmnode == mnode);
+                        trace!(
+                            "ModelFIO::overlaps(&cur_segment_range, &read_range) = {}",
+                            ModelFIO::overlaps(&cur_segment_range, &read_range)
+                        );
+                        if *wmnode == mnode && ModelFIO::overlaps(&cur_segment_range, &read_range) {
+                            let _r = ModelFIO::intersection(read_range, cur_segment_range).map(
+                                |overlapping_range| {
+                                    trace!("overlapping_range = {:?}", overlapping_range);
+                                    for idx in overlapping_range {
+                                        if buffer_gatherer[idx - offset as usize].is_none() {
+                                            // No earlier write, we know that 'pattern' must be at idx
+                                            buffer_gatherer[idx - offset as usize] =
+                                                Some(*fpattern as u8);
+                                        }
+                                    }
+                                    trace!("buffer_gatherer = {:?}", buffer_gatherer);
+                                },
+                            );
+                        }
+                        // else: The write is not relevant
+                    }
+
+                    ModelOperation::Created(_path, mode, cmnode) => {
+                        if mnode == *cmnode && !FileModes::from(*mode).is_readable() {
+                            return Err(SystemCallError::InternalError);
+                        }
+                    }
+                }
+            }
+            // We need to copy buffer gatherer back in buffer:
+            // Something like [1, 2, 3, None] -> Should lead to [1, 2, 3] with Ok(3)
+            // Something like [1, None, 3, 4, None] -> Should lead to [1, 0, 3] with Ok(4), I guess?
+            let _iter = buffer_gatherer.iter().enumerate().rev();
+            let mut drop_top = true;
+            let mut bytes_read = 0;
+            let mut slice = unsafe { from_raw_parts_mut(buffer as *mut u8, len as usize) };
+            for (idx, val) in buffer_gatherer.iter().enumerate().rev() {
+                if drop_top {
+                    if val.is_some() {
+                        bytes_read += 1;
+                        drop_top = false;
+                    } else {
+                        // All None's at the end (rev() above) don't count towards
+                        // total bytes read since the file wasn't that big
+                    }
+                } else {
+                    bytes_read += 1;
+                }
+
+                slice[idx] = val.unwrap_or(0);
+                trace!("buffer = {:?}", slice);
+            }
+
+            fd.update_offset(offset as usize + len as usize);
+            Ok(bytes_read)
+        } else {
+            Err(SystemCallError::InternalError)
+        }
+    }
+
+    /// Lookup just returns the mnode.
+    fn lookup(&self, pathname: &str) -> Option<Mnode> {
+        self.path_to_mnode(&String::from(pathname))
+    }
+
+    /// Delete finds sand removes a path from the oplog again.
+    pub fn delete(&self, name: u64) -> Result<bool, SystemCallError> {
+        let path = userptr_to_str(name)?;
+        if let Some(mnode) = self.lookup(&path) {
+            // Check to see if there are any open fds to this mnode.
+            // If not, we delete the file.
+            if let Err(_) = self.fds.get_fd(mnode as usize) {
+                if let Some(idx) = self.path_to_idx(&path) {
+                    self.oplog.borrow_mut().remove(idx);
+                    // We leave corresponding ModelOperation::Write entries
+                    // in the log for now...
+                    return Ok(true);
+                }
+            }
+        }
+        Err(SystemCallError::InternalError)
+    }
+
+    pub fn close(&mut self, fd: u64) -> Result<u64, SystemCallError> {
+        self.fds.deallocate_fd(fd)?;
+        Ok(0)
+    }
+}
+
+/// Two writes/reads at different offsets should return
+/// the correct result.
+fn model_read() {
+    let mut mfs: ModelFIO = Default::default();
+    let fd = mfs
+        .open(
+            "/bla".as_ptr() as u64,
+            u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+            FileModes::S_IRWXU.into(),
+        )
+        .unwrap();
+
+    let mut wdata1: [u8; 2] = [1, 1];
+    let r = mfs.write_at(fd, wdata1.as_ptr() as u64, 2, 0);
+    assert_eq!(r, Ok(2));
+
+    let mut wdata: [u8; 2] = [2, 2];
+    let r = mfs.write_at(fd, wdata.as_ptr() as u64, 2, 2);
+    assert_eq!(r, Ok(2));
+
+    let mut rdata: [u8; 2] = [0, 0];
+
+    let r = mfs.read_at(fd, rdata.as_ptr() as u64, 2, 0);
+    assert_eq!(rdata, [1, 1]);
+    assert_eq!(r, Ok(2));
+
+    let r = mfs.read_at(fd, rdata.as_ptr() as u64, 2, 2);
+    assert_eq!(rdata, [2, 2]);
+    assert_eq!(r, Ok(2));
+}
+
+/// Two writes that overlap with each other should return
+/// the last write.
+///
+/// Also providing a larger buffer returns 0 in those entries.
+fn model_overlapping_writes() {
+    let mut mfs: ModelFIO = Default::default();
+    let fd = mfs
+        .open(
+            "/bla".as_ptr() as u64,
+            u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+            FileModes::S_IRWXU.into(),
+        )
+        .unwrap();
+
+    let mut data: [u8; 3] = [1, 1, 1];
+    let r = mfs.write(fd, data.as_ptr() as u64, 3);
+    assert_eq!(r, Ok(3));
+
+    let mut wdata: [u8; 3] = [2, 2, 2];
+    let r = mfs.write_at(fd, wdata.as_ptr() as u64, 3, 2);
+
+    let mut rdata: [u8; 6] = [0, 0, 0, 0, 0, 0];
+    let r = mfs.read_at(fd, rdata.as_ptr() as u64, 5, 0);
+    assert_eq!(r, Ok(5));
+    assert_eq!(rdata, [1, 1, 2, 2, 2, 0]);
+}
+
+/// Actions that we can perform against the model and the implementation.
+///
+/// One entry for each function in the FileSystem interface and
+/// necessary arguments to construct an operation for said function.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TestAction {
+    Read(u64, u64),
+    Write(u64, char, u64),
+    ReadAt(u64, u64, i64),
+    WriteAt(u64, char, u64, i64),
+    Open(Vec<String>, u64, u64),
+    Delete(Vec<String>),
+    Close(u64),
+}
+
+/// Generates one `TestAction` entry randomly.
+fn action() -> impl Strategy<Value = TestAction> {
+    prop_oneof![
+        (fd_gen(0xA), size_gen(128)).prop_map(|(a, c)| TestAction::Read(a, c)),
+        (fd_gen(0xA), fill_pattern(), size_gen(64))
+            .prop_map(|(a, c, d)| TestAction::Write(a, c, d)),
+        (fd_gen(0xA), size_gen(128), offset_gen(0x1000))
+            .prop_map(|(a, b, c)| TestAction::ReadAt(a, b, c)),
+        (
+            fd_gen(0xA),
+            fill_pattern(),
+            size_gen(64),
+            offset_gen(0x1000),
+        )
+            .prop_map(|(a, b, c, d)| TestAction::WriteAt(a, b, c, d)),
+        (path(), flag_gen(0xfff), mode_gen(0xfff)).prop_map(|(a, b, c)| TestAction::Open(a, b, c)),
+        path().prop_map(TestAction::Delete),
+        fd_gen(0xA).prop_map(TestAction::Close),
+    ]
+}
+
+/// Generates a vector of TestAction entries (by repeatingly calling `action`).
+fn actions() -> impl Strategy<Value = Vec<TestAction>> {
+    prop::collection::vec(action(), 0..512)
+}
+
+/// Generates one fill pattern (for writes).
+fn fill_pattern() -> impl Strategy<Value = char> {
+    prop_oneof![
+        Just('a'),
+        Just('b'),
+        Just('c'),
+        Just('d'),
+        Just('e'),
+        Just('f'),
+        Just('g'),
+        Just('.')
+    ]
+}
+
+// Generates an offset.
+prop_compose! {
+    fn offset_gen(max: i64)(offset in 0..max) -> i64 { offset }
+}
+
+// Generates a random file descriptor.
+const FD_OFFSET: u64 = 100;
+prop_compose! {
+    fn fd_gen(max: u64)(mnode in 0..max) -> u64 { mnode }
+}
+
+// Generates a random mode.
+prop_compose! {
+    fn mode_gen(max: u64)(mode in 0..max) -> u64 { mode }
+}
+
+// Generates a random file flag.
+prop_compose! {
+    fn flag_gen(max: u64)(flag in 0..max) -> u64 { flag }
+}
+
+// Generates a random (read/write)-request size.
+prop_compose! {
+    fn size_gen(max: u64)(size in 0..max) -> u64 { size }
+}
+
+/// Generates a random path entry.
+fn path_names() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::from("/")),
+        Just(String::from("nrk")),
+        Just(String::from("hello")),
+        Just(String::from("world")),
+        Just(String::from("memory")),
+        Just(String::from("the")),
+        Just(String::from("fs")),
+        Just(String::from("rusty")),
+        Just(String::from("os"))
+    ]
+}
+
+/// Creates a path of depth a given depth (4), represented as a
+/// vector of Strings.
+fn path() -> impl Strategy<Value = Vec<String>> {
+    proptest::collection::vec(path_names(), 4)
+}
+
+// Verify that our FS implementation behaves according to the `ModelFileSystem`.
+fn model_equivalence(ops: Vec<TestAction>) {
+    let mut model: ModelFIO = Default::default();
+    let mut fd_map: HashMap<u64, u64> = HashMap::new();
+
+    use TestAction::*;
+    for action in ops {
+        log::debug!("{:?}", action);
+        match action {
+            Read(fd, len) => {
+                let mut rtotest_fd = fd + FD_OFFSET;
+                if fd_map.contains_key(&fd) {
+                    rtotest_fd = *fd_map.get(&fd).unwrap();
+                }
+
+                let mut buffer1: Vec<u8> = Vec::with_capacity(len as usize);
+                let mut buffer2: Vec<u8> = Vec::with_capacity(len as usize);
+
+                //let rmodel = model.read(fd, buffer1.as_mut_ptr() as u64, len);
+                let rtotest =
+                    vibrio::syscalls::Fs::read(rtotest_fd, buffer2.as_mut_ptr() as u64, len);
+                //assert_eq!(rmodel, rtotest);
+                //assert_eq!(buffer1, buffer2);
+            }
+            Write(fd, pattern, len) => {
+                let mut rtotest_fd = fd + FD_OFFSET;
+                if fd_map.contains_key(&fd) {
+                    rtotest_fd = *fd_map.get(&fd).unwrap();
+                }
+
+                let mut buffer: Vec<u8> = Vec::with_capacity(len as usize);
+                for _i in 0..len {
+                    buffer.push(pattern as u8);
+                }
+
+                //let rmodel = model.write(fd, buffer.as_mut_ptr() as u64, len);
+                let rtotest =
+                    vibrio::syscalls::Fs::write(rtotest_fd, buffer.as_mut_ptr() as u64, len);
+                //assert_eq!(rmodel, rtotest);
+            }
+            ReadAt(fd, len, offset) => {
+                let mut rtotest_fd = fd + FD_OFFSET;
+                if fd_map.contains_key(&fd) {
+                    rtotest_fd = *fd_map.get(&fd).unwrap();
+                }
+
+                let mut buffer1: Vec<u8> = Vec::with_capacity(len as usize);
+                let mut buffer2: Vec<u8> = Vec::with_capacity(len as usize);
+
+                //let rmodel = model.read_at(fd, buffer1.as_mut_ptr() as u64, len, offset);
+                let rtotest = vibrio::syscalls::Fs::read_at(
+                    rtotest_fd,
+                    buffer1.as_mut_ptr() as u64,
+                    len,
+                    offset,
+                );
+                //assert_eq!(buffer1, buffer2);
+                //assert_eq!(rmodel, rtotest);
+            }
+            WriteAt(fd, pattern, len, offset) => {
+                let mut rtotest_fd = fd + FD_OFFSET;
+                if fd_map.contains_key(&fd) {
+                    rtotest_fd = *fd_map.get(&fd).unwrap();
+                }
+
+                let mut buffer: Vec<u8> = Vec::with_capacity(len as usize);
+                for _i in 0..len {
+                    buffer.push(pattern as u8);
+                }
+
+                //let rmodel = model.write_at(fd, buffer.as_mut_ptr() as u64, len, offset);
+                let rtotest = vibrio::syscalls::Fs::write_at(
+                    rtotest_fd,
+                    buffer.as_mut_ptr() as u64,
+                    len,
+                    offset,
+                );
+                //assert_eq!(rmodel, rtotest);
+            }
+            Open(path, flags, mode) => {
+                let path_str = path.join("/");
+                //let rmodel = model.open(path_str.as_ptr() as u64, flags, mode);
+                let rtotest = vibrio::syscalls::Fs::open(path_str.as_ptr() as u64, flags, mode);
+                //assert_eq!(rmodel.is_ok(), rtotest.is_ok());
+
+                // Add mapping from rmodel_fd -> rtotest_fd
+                //if rmodel.is_ok() {
+                //    fd_map.insert(rmodel.unwrap(), rtotest.unwrap());
+                //}
+            }
+            Delete(path) => {
+                let path_str = path.join("/");
+
+                //let rmodel = model.delete(path_str.as_ptr() as u64);
+                let rtotest = vibrio::syscalls::Fs::delete(path_str.as_ptr() as u64);
+                //assert_eq!(rmodel, rtotest);
+            }
+            Close(fd) => {
+                let mut rtotest_fd = fd + FD_OFFSET;
+                if fd_map.contains_key(&fd) {
+                    rtotest_fd = *fd_map.get(&fd).unwrap();
+                }
+
+                //let rmodel = model.close(fd);
+                let rtotest = vibrio::syscalls::Fs::close(rtotest_fd);
+                //assert_eq!(rmodel, rtotest);
+
+                // Remove mapping from rmodel_fd -> rtotest_fd
+                //if rmodel.is_ok() && fd_map.contains_key(&fd) {
+                //    fd_map.remove(&fd);
+                //}
+            }
+        }
+    }
+}
+
+pub fn run_fio_syscall_proptests() {
+    model_read();
+    model_overlapping_writes();
+    proptest!( |(ops in actions())| {
+        model_equivalence(ops);
+    });
+}
 
 /// Create a file with non-read permission and try to read it.
 fn test_file_read_permission_error() {
@@ -215,7 +977,6 @@ fn test_file_delete() {
     assert_eq!(ret, Err(SystemCallError::InternalError));
 }
 
-/*
 fn test_file_delete_open() {
     // Create file
     let fd = vibrio::syscalls::Fs::open(
@@ -231,7 +992,6 @@ fn test_file_delete_open() {
 
     vibrio::syscalls::Fs::close(fd).unwrap();
 }
-*/
 
 fn test_file_rename() {
     // Create old

--- a/usr/init/src/fs.rs
+++ b/usr/init/src/fs.rs
@@ -1,0 +1,474 @@
+// Copyright © 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Test file-system syscall implementation using unit-tests.
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::cmp::{Eq, PartialEq};
+use core::slice::{from_raw_parts, from_raw_parts_mut};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::alloc::borrow::ToOwned;
+
+use kpi::io::*;
+use kpi::SystemCallError;
+
+use log::trace;
+
+/// Create a file with non-read permission and try to read it.
+fn test_file_read_permission_error() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_read_permission_error.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_WRONLY | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let mut rdata = [0u8; 6];
+    assert_eq!(
+        vibrio::syscalls::Fs::read(fd, rdata.as_mut_ptr() as u64, 6),
+        Err(SystemCallError::InternalError)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+/// Create a file with non-write permission and try to write it.
+fn test_file_write_permission_error() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_write_permission_error.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDONLY | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let mut wdata = [0u8; 6];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_mut_ptr() as u64, 6),
+        Err(SystemCallError::InternalError)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+/// Create a file and write to it.
+fn test_file_write() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_write.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let mut wdata = [0u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+/// Create a file, write to it and then later read. Verify the content.
+fn test_file_read() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_read.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    let wdata = [1u8; 10];
+    let mut rdata = [0u8; 10];
+
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    assert_eq!(
+        vibrio::syscalls::Fs::read_at(fd, rdata.as_mut_ptr() as u64, 10, 0),
+        Ok(10)
+    );
+    assert_eq!(rdata[0], 1);
+    assert_eq!(rdata[5], 1);
+    assert_eq!(rdata[9], 1);
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+/// Create a file and open again without create permission
+fn test_file_duplicate_open() {
+    let fd1 = vibrio::syscalls::Fs::open(
+        "test_file_duplicate_open.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let fd2 = vibrio::syscalls::Fs::open(
+        "test_file_duplicate_open.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    assert_ne!(fd1, fd2);
+    vibrio::syscalls::Fs::close(fd1).unwrap();
+    vibrio::syscalls::Fs::close(fd2).unwrap();
+}
+
+/// Attempt to open file that is not present
+fn test_file_fake_open() {
+    let ret = vibrio::syscalls::Fs::open(
+        "test_file_fake_open.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    );
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+}
+
+fn test_file_fake_close() {
+    let ret = vibrio::syscalls::Fs::close(10536);
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+}
+
+fn test_file_duplicate_close() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_duplicate_close.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    assert_eq!(vibrio::syscalls::Fs::close(fd), Ok(0));
+    assert_eq!(vibrio::syscalls::Fs::close(fd), Err(SystemCallError::InternalError));
+}
+
+/// Ensure you can write and write with multiple file descriptors
+fn test_file_multiple_fd() {
+    // Open the same file twice
+    let fd1 = vibrio::syscalls::Fs::open(
+        "test_file_multiple_fd.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let fd2 = vibrio::syscalls::Fs::open(
+        "test_file_multiple_fd.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    // Write to file with fd2 & close fd2
+    let wdata = [1u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd2, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    vibrio::syscalls::Fs::close(fd2).unwrap();
+
+    // Read from file with fd1 & close fd1
+    let mut rdata = [0u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::read_at(fd1, rdata.as_mut_ptr() as u64, 10, 0),
+        Ok(10)
+    );
+    assert_eq!(rdata[0], 1);
+    assert_eq!(rdata[5], 1);
+    assert_eq!(rdata[9], 1);
+    vibrio::syscalls::Fs::close(fd1).unwrap();
+}
+
+/// Test file_info.
+fn test_file_info() {
+    // Create file
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_info.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Get file info
+    let ret = vibrio::syscalls::Fs::getinfo("test_file_info.txt".as_ptr() as u64);
+    assert_eq!(ret, Ok(FileInfo { ftype: 2, fsize: 0 }));
+}
+
+/// Test file deletion.
+fn test_file_delete() {
+    // Create file
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_info.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Delete file
+    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt".as_ptr() as u64);
+    assert_eq!(ret, Ok(true));
+
+    // Attempt to open deleted file
+    let ret = vibrio::syscalls::Fs::open(
+        "test_file_info.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    );
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+}
+
+/*
+fn test_file_delete_open() {
+    // Create file
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_info.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    
+    // Delete file
+    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt".as_ptr() as u64);
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+*/
+
+fn test_file_rename() {
+    // Create old
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Rename
+    let ret = vibrio::syscalls::Fs::rename(
+        "test_file_rename_old.txt".as_ptr() as u64,
+        "test_file_rename_new.txt".as_ptr() as u64,
+    );
+    assert_eq!(ret.is_ok(), true);
+
+    // Attempt to open old
+    let ret = vibrio::syscalls::Fs::open(
+        "test_file_rename_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    );
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+
+    // Attempt to open new
+    let ret = vibrio::syscalls::Fs::open(
+        "test_file_rename_new.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    );
+    assert_eq!(ret.is_ok(), true);
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+fn test_file_rename_and_read() {
+    // Create old
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_and_read_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    // Write and close
+    let wdata = [1u8; 9];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 9),
+        Ok(9)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Rename
+    let ret = vibrio::syscalls::Fs::rename(
+        "test_file_rename_and_read_old.txt".as_ptr() as u64,
+        "test_file_rename_and_read_new.txt".as_ptr() as u64,
+    );
+    assert_eq!(ret, Ok(0));
+
+    // Open new
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_and_read_new.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    // Read
+    let mut rdata = [0u8; 9];
+    assert_eq!(
+        vibrio::syscalls::Fs::read_at(fd, rdata.as_mut_ptr() as u64, 9, 0),
+        Ok(9)
+    );
+    assert_eq!(rdata[0], 1);
+    assert_eq!(rdata[5], 1);
+    assert_eq!(rdata[8], 1);
+
+    // Close
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+fn test_file_rename_and_write() {
+    // Create old
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_and_write_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Rename
+    let ret = vibrio::syscalls::Fs::rename(
+        "test_file_rename_and_write_old.txt".as_ptr() as u64,
+        "test_file_rename_and_write_new.txt".as_ptr() as u64,
+    );
+    assert_eq!(ret, Ok(0));
+
+    // Open new
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_and_write_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    // Write
+    let wdata = [1u8; 9];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 9),
+        Ok(9)
+    );
+
+    // Read
+    let mut rdata = [0u8; 9];
+    assert_eq!(
+        vibrio::syscalls::Fs::read_at(fd, rdata.as_mut_ptr() as u64, 9, 0),
+        Ok(9)
+    );
+    assert_eq!(rdata[0], 1);
+    assert_eq!(rdata[5], 1);
+    assert_eq!(rdata[8], 1);
+
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+fn test_file_rename_nonexistent_file() {
+    let ret = vibrio::syscalls::Fs::rename(
+        "test_file_rename_nonexistent_file_old.txt".as_ptr() as u64,
+        "test_file_rename_nonexistent_file_new.txt".as_ptr() as u64,
+    );
+    assert_eq!(ret, Err(SystemCallError::InternalError));
+}
+
+fn test_file_rename_to_existent_file() {
+    // Create existing file & write some data to it & close the fd
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let wdata = [1u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Create the old file & write some data to it & close the fd
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_to_existent_file_old.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let wdata = [2u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    vibrio::syscalls::Fs::close(fd).unwrap();
+
+    // Rename old file to existing file
+    let ret = vibrio::syscalls::Fs::rename(
+        "test_file_rename_to_existent_file_old.txt".as_ptr() as u64,
+        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+    );
+    assert_eq!(ret, Ok(0));
+
+    // Open existing file, check it has old file's data
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+    let mut rdata = [2u8; 10];
+    assert_eq!(
+        vibrio::syscalls::Fs::read(fd, rdata.as_mut_ptr() as u64, 10),
+        Ok(10)
+    );
+    assert_eq!(rdata[0], 2);
+    assert_eq!(rdata[5], 2);
+    assert_eq!(rdata[9], 2);
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+/// Tests read_at and write_at
+fn test_file_position() {
+    let fd = vibrio::syscalls::Fs::open(
+        "test_file_position.txt".as_ptr() as u64,
+        u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
+        FileModes::S_IRWXU.into(),
+    )
+    .unwrap();
+
+    let wdata = [1u8; 10];
+    let wdata2 = [2u8; 10];
+    let mut rdata = [0u8; 10];
+
+    assert_eq!(
+        vibrio::syscalls::Fs::write(fd, wdata.as_ptr() as u64, 10),
+        Ok(10)
+    );
+    assert_eq!(
+        vibrio::syscalls::Fs::write_at(fd, wdata2.as_ptr() as u64, 10, 5),
+        Ok(10)
+    );
+    assert_eq!(
+        vibrio::syscalls::Fs::read_at(fd, rdata.as_mut_ptr() as u64, 10, 2),
+        Ok(10)
+    );
+    assert_eq!(rdata[0], 1);
+    assert_eq!(rdata[2], 1);
+    assert_eq!(rdata[3], 2);
+    assert_eq!(rdata[9], 2);
+
+    vibrio::syscalls::Fs::close(fd).unwrap();
+}
+
+pub fn run_fio_syscall_tests() {
+    test_file_read_permission_error();
+    test_file_write_permission_error();
+    test_file_write();
+    test_file_read();
+    test_file_duplicate_open();
+    test_file_fake_open();
+    test_file_fake_close();
+    test_file_duplicate_close();
+    test_file_multiple_fd();
+    test_file_info();
+    test_file_delete();
+    // TODO: check if this test is correct 
+    //test_file_delete_open();
+    test_file_rename();
+    test_file_rename_and_read();
+    test_file_rename_and_write();
+    test_file_rename_nonexistent_file();
+    test_file_rename_to_existent_file();
+    test_file_position();
+}

--- a/usr/init/src/fs.rs
+++ b/usr/init/src/fs.rs
@@ -133,7 +133,10 @@ fn test_file_duplicate_close() {
     )
     .unwrap();
     assert_eq!(vibrio::syscalls::Fs::close(fd), Ok(0));
-    assert_eq!(vibrio::syscalls::Fs::close(fd), Err(SystemCallError::InternalError));
+    assert_eq!(
+        vibrio::syscalls::Fs::close(fd),
+        Err(SystemCallError::InternalError)
+    );
 }
 
 /// Ensure you can write and write with multiple file descriptors
@@ -221,7 +224,7 @@ fn test_file_delete_open() {
         FileModes::S_IRWXU.into(),
     )
     .unwrap();
-    
+
     // Delete file
     let ret = vibrio::syscalls::Fs::delete("test_file_info.txt".as_ptr() as u64);
     assert_eq!(ret, Err(SystemCallError::InternalError));
@@ -463,7 +466,7 @@ pub fn run_fio_syscall_tests() {
     test_file_multiple_fd();
     test_file_info();
     test_file_delete();
-    // TODO: check if this test is correct 
+    // TODO: check if this test is correct
     //test_file_delete_open();
     test_file_rename();
     test_file_rename_and_read();

--- a/usr/init/src/fs.rs
+++ b/usr/init/src/fs.rs
@@ -14,8 +14,8 @@ use hashbrown::HashMap;
 
 use crate::alloc::borrow::ToOwned;
 
-use kpi::io::*;
-use kpi::SystemCallError;
+use vibrio::io::*;
+use vibrio::SystemCallError;
 use x86::bits64::paging::{PAddr, VAddr};
 
 use log::trace;
@@ -910,7 +910,7 @@ pub fn run_fio_syscall_proptests() {
 /// Create a file with non-read permission and try to read it.
 fn test_file_read_permission_error() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_read_permission_error.txt".as_ptr() as u64,
+        "test_file_read_permission_error.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_WRONLY | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -926,7 +926,7 @@ fn test_file_read_permission_error() {
 /// Create a file with non-write permission and try to write it.
 fn test_file_write_permission_error() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_write_permission_error.txt".as_ptr() as u64,
+        "test_file_write_permission_error.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDONLY | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -942,7 +942,7 @@ fn test_file_write_permission_error() {
 /// Create a file and write to it.
 fn test_file_write() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_write.txt".as_ptr() as u64,
+        "test_file_write.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -958,7 +958,7 @@ fn test_file_write() {
 /// Create a file, write to it and then later read. Verify the content.
 fn test_file_read() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_read.txt".as_ptr() as u64,
+        "test_file_read.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -984,13 +984,13 @@ fn test_file_read() {
 /// Create a file and open again without create permission
 fn test_file_duplicate_open() {
     let fd1 = vibrio::syscalls::Fs::open(
-        "test_file_duplicate_open.txt".as_ptr() as u64,
+        "test_file_duplicate_open.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
     .unwrap();
     let fd2 = vibrio::syscalls::Fs::open(
-        "test_file_duplicate_open.txt".as_ptr() as u64,
+        "test_file_duplicate_open.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     )
@@ -1003,7 +1003,7 @@ fn test_file_duplicate_open() {
 /// Attempt to open file that is not present
 fn test_file_fake_open() {
     let ret = vibrio::syscalls::Fs::open(
-        "test_file_fake_open.txt".as_ptr() as u64,
+        "test_file_fake_open.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     );
@@ -1017,7 +1017,7 @@ fn test_file_fake_close() {
 
 fn test_file_duplicate_close() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_duplicate_close.txt".as_ptr() as u64,
+        "test_file_duplicate_close.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1033,13 +1033,13 @@ fn test_file_duplicate_close() {
 fn test_file_multiple_fd() {
     // Open the same file twice
     let fd1 = vibrio::syscalls::Fs::open(
-        "test_file_multiple_fd.txt".as_ptr() as u64,
+        "test_file_multiple_fd.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
     .unwrap();
     let fd2 = vibrio::syscalls::Fs::open(
-        "test_file_multiple_fd.txt".as_ptr() as u64,
+        "test_file_multiple_fd.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     )
@@ -1069,7 +1069,7 @@ fn test_file_multiple_fd() {
 fn test_file_info() {
     // Create file
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_info.txt".as_ptr() as u64,
+        "test_file_info.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1077,7 +1077,7 @@ fn test_file_info() {
     vibrio::syscalls::Fs::close(fd).unwrap();
 
     // Get file info
-    let ret = vibrio::syscalls::Fs::getinfo("test_file_info.txt".as_ptr() as u64);
+    let ret = vibrio::syscalls::Fs::getinfo("test_file_info.txt\0".as_ptr() as u64);
     assert_eq!(ret, Ok(FileInfo { ftype: 2, fsize: 0 }));
 }
 
@@ -1085,7 +1085,7 @@ fn test_file_info() {
 fn test_file_delete() {
     // Create file
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_info.txt".as_ptr() as u64,
+        "test_file_info.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1093,12 +1093,12 @@ fn test_file_delete() {
     vibrio::syscalls::Fs::close(fd).unwrap();
 
     // Delete file
-    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt".as_ptr() as u64);
+    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt\0".as_ptr() as u64);
     assert_eq!(ret, Ok(true));
 
     // Attempt to open deleted file
     let ret = vibrio::syscalls::Fs::open(
-        "test_file_info.txt".as_ptr() as u64,
+        "test_file_info.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     );
@@ -1108,14 +1108,14 @@ fn test_file_delete() {
 fn test_file_delete_open() {
     // Create file
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_info.txt".as_ptr() as u64,
+        "test_file_info.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
     .unwrap();
 
     // Delete file
-    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt".as_ptr() as u64);
+    let ret = vibrio::syscalls::Fs::delete("test_file_info.txt\0".as_ptr() as u64);
     assert_eq!(ret, Err(SystemCallError::InternalError));
 
     vibrio::syscalls::Fs::close(fd).unwrap();
@@ -1124,7 +1124,7 @@ fn test_file_delete_open() {
 fn test_file_rename() {
     // Create old
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_old.txt".as_ptr() as u64,
+        "test_file_rename_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1133,14 +1133,14 @@ fn test_file_rename() {
 
     // Rename
     let ret = vibrio::syscalls::Fs::rename(
-        "test_file_rename_old.txt".as_ptr() as u64,
-        "test_file_rename_new.txt".as_ptr() as u64,
+        "test_file_rename_old.txt\0".as_ptr() as u64,
+        "test_file_rename_new.txt\0".as_ptr() as u64,
     );
     assert_eq!(ret.is_ok(), true);
 
     // Attempt to open old
     let ret = vibrio::syscalls::Fs::open(
-        "test_file_rename_old.txt".as_ptr() as u64,
+        "test_file_rename_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     );
@@ -1148,7 +1148,7 @@ fn test_file_rename() {
 
     // Attempt to open new
     let ret = vibrio::syscalls::Fs::open(
-        "test_file_rename_new.txt".as_ptr() as u64,
+        "test_file_rename_new.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     );
@@ -1159,7 +1159,7 @@ fn test_file_rename() {
 fn test_file_rename_and_read() {
     // Create old
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_and_read_old.txt".as_ptr() as u64,
+        "test_file_rename_and_read_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1175,14 +1175,14 @@ fn test_file_rename_and_read() {
 
     // Rename
     let ret = vibrio::syscalls::Fs::rename(
-        "test_file_rename_and_read_old.txt".as_ptr() as u64,
-        "test_file_rename_and_read_new.txt".as_ptr() as u64,
+        "test_file_rename_and_read_old.txt\0".as_ptr() as u64,
+        "test_file_rename_and_read_new.txt\0".as_ptr() as u64,
     );
     assert_eq!(ret, Ok(0));
 
     // Open new
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_and_read_new.txt".as_ptr() as u64,
+        "test_file_rename_and_read_new.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     )
@@ -1205,7 +1205,7 @@ fn test_file_rename_and_read() {
 fn test_file_rename_and_write() {
     // Create old
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_and_write_old.txt".as_ptr() as u64,
+        "test_file_rename_and_write_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1214,14 +1214,14 @@ fn test_file_rename_and_write() {
 
     // Rename
     let ret = vibrio::syscalls::Fs::rename(
-        "test_file_rename_and_write_old.txt".as_ptr() as u64,
-        "test_file_rename_and_write_new.txt".as_ptr() as u64,
+        "test_file_rename_and_write_old.txt\0".as_ptr() as u64,
+        "test_file_rename_and_write_new.txt\0".as_ptr() as u64,
     );
     assert_eq!(ret, Ok(0));
 
     // Open new
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_and_write_old.txt".as_ptr() as u64,
+        "test_file_rename_and_write_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1249,8 +1249,8 @@ fn test_file_rename_and_write() {
 
 fn test_file_rename_nonexistent_file() {
     let ret = vibrio::syscalls::Fs::rename(
-        "test_file_rename_nonexistent_file_old.txt".as_ptr() as u64,
-        "test_file_rename_nonexistent_file_new.txt".as_ptr() as u64,
+        "test_file_rename_nonexistent_file_old.txt\0".as_ptr() as u64,
+        "test_file_rename_nonexistent_file_new.txt\0".as_ptr() as u64,
     );
     assert_eq!(ret, Err(SystemCallError::InternalError));
 }
@@ -1258,7 +1258,7 @@ fn test_file_rename_nonexistent_file() {
 fn test_file_rename_to_existent_file() {
     // Create existing file & write some data to it & close the fd
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+        "test_file_rename_to_existent_file_existing.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1272,7 +1272,7 @@ fn test_file_rename_to_existent_file() {
 
     // Create the old file & write some data to it & close the fd
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_to_existent_file_old.txt".as_ptr() as u64,
+        "test_file_rename_to_existent_file_old.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )
@@ -1286,14 +1286,14 @@ fn test_file_rename_to_existent_file() {
 
     // Rename old file to existing file
     let ret = vibrio::syscalls::Fs::rename(
-        "test_file_rename_to_existent_file_old.txt".as_ptr() as u64,
-        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+        "test_file_rename_to_existent_file_old.txt\0".as_ptr() as u64,
+        "test_file_rename_to_existent_file_existing.txt\0".as_ptr() as u64,
     );
     assert_eq!(ret, Ok(0));
 
     // Open existing file, check it has old file's data
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_rename_to_existent_file_existing.txt".as_ptr() as u64,
+        "test_file_rename_to_existent_file_existing.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR),
         FileModes::S_IRWXU.into(),
     )
@@ -1312,7 +1312,7 @@ fn test_file_rename_to_existent_file() {
 /// Tests read_at and write_at
 fn test_file_position() {
     let fd = vibrio::syscalls::Fs::open(
-        "test_file_position.txt".as_ptr() as u64,
+        "test_file_position.txt\0".as_ptr() as u64,
         u64::from(FileFlags::O_RDWR | FileFlags::O_CREAT),
         FileModes::S_IRWXU.into(),
     )

--- a/usr/init/src/init.rs
+++ b/usr/init/src/init.rs
@@ -41,10 +41,10 @@ use log::{debug, error, info, Level, Metadata, Record, SetLoggerError};
 mod vmops;
 
 mod f64;
+mod fs;
 #[cfg(feature = "fxmark")]
 mod fxmark;
 mod histogram;
-mod fs;
 
 use crate::fs::run_fio_syscall_tests;
 

--- a/usr/init/src/init.rs
+++ b/usr/init/src/init.rs
@@ -11,6 +11,7 @@
 #![feature(core_intrinsics)]
 #![allow(unused_imports, dead_code)]
 extern crate alloc;
+extern crate kpi;
 extern crate spin;
 extern crate vibrio;
 extern crate x86;
@@ -43,6 +44,9 @@ mod f64;
 #[cfg(feature = "fxmark")]
 mod fxmark;
 mod histogram;
+mod fs;
+
+use crate::fs::run_fio_syscall_tests;
 
 #[thread_local]
 pub static mut TLS_TEST: [&str; 2] = ["abcd", "efgh"];
@@ -559,6 +563,7 @@ fn fs_test() {
         test_fs_invalid_addresses();
     }
 
+    run_fio_syscall_tests();
     info!("fs_test OK");
 }
 

--- a/usr/init/src/init.rs
+++ b/usr/init/src/init.rs
@@ -46,7 +46,7 @@ mod fs;
 mod fxmark;
 mod histogram;
 
-use crate::fs::run_fio_syscall_tests;
+use crate::fs::{run_fio_syscall_proptests, run_fio_syscall_tests};
 
 #[thread_local]
 pub static mut TLS_TEST: [&str; 2] = ["abcd", "efgh"];
@@ -567,6 +567,11 @@ fn fs_test() {
     info!("fs_test OK");
 }
 
+fn fs_prop_test() {
+    run_fio_syscall_proptests();
+    info!("fs_prop_test OK");
+}
+
 fn fs_write_test() {
     use vibrio::syscalls::Fs;
 
@@ -678,6 +683,9 @@ pub extern "C" fn _start() -> ! {
 
     #[cfg(feature = "fs-write")]
     fs_write_test();
+
+    #[cfg(feature = "test-fs-prop")]
+    fs_prop_test();
 
     #[cfg(feature = "fxmark")]
     fxmark::bench(ncores, open_files, benchmark, write_ratio);

--- a/usr/init/src/init.rs
+++ b/usr/init/src/init.rs
@@ -11,7 +11,6 @@
 #![feature(core_intrinsics)]
 #![allow(unused_imports, dead_code)]
 extern crate alloc;
-extern crate kpi;
 extern crate spin;
 extern crate vibrio;
 extern crate x86;


### PR DESCRIPTION
Added file system system call unit tests to the integration test test_fs. Created new integration test, test_fs_prop, which includes property tests based on file system system calls.  

During this process, I found (and fixed) what I believe to be a small bug in deallocate_fd() in error handling, and another small bug in the error handling of the call to truncate as part of the open() system call. 