### PR TITLE
Add fxmark test for rackscale shmem configuration

### DIFF
--- a/lib/rpc/src/transport/shmem/mod.rs
+++ b/lib/rpc/src/transport/shmem/mod.rs
@@ -1,6 +1,4 @@
 // Shmem Transport
-#![allow(dead_code)]
-
 use alloc::alloc::Allocator;
 
 use alloc::sync::Arc;

--- a/lib/rpc/src/transport/shmem/queue_mpmc.rs
+++ b/lib/rpc/src/transport/shmem/queue_mpmc.rs
@@ -5,8 +5,6 @@
 // http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 // This queue is copy pasted from old rust stdlib.
 
-#![allow(warnings)] // For now...
-
 use alloc::alloc::{alloc, Layout};
 use alloc::boxed::Box;
 use alloc::sync::Arc;

--- a/lib/rpc/tests/integration-test.rs
+++ b/lib/rpc/tests/integration-test.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #[test]
-fn test_client_server() {
+#[cfg(feature = "std")]
+fn test_client_server_mpsc() {
     use std::sync::mpsc::sync_channel;
     use std::thread;
 


### PR DESCRIPTION
Added test to make it easier to track performance for the shmem RPC transport.

Some notes:
* It would be easy to create a similar test for smoltcp if desired, but I didn't do it here because I didn't want to increase the time it takes to run integration tests since I don't see a current use case for it
* It only tests read and write, same as the original fxmark benchmark, but it is still helpful in measuring file system RPC call performance
* Results are not directly directly comparable to the original fxmark_benchmark test since that test uses multiple cores and we're still only working on one core for both client/controller in rackscale builds.