### PR TITLE
Add DCM dependency and rackscale network configuration documentation

### DIFF
--- a/doc/src/development/Building.md
+++ b/doc/src/development/Building.md
@@ -37,7 +37,8 @@ can install both build and run dependencies by executing `setup.sh` in the root
 of the repository directly on your machine (*this requires the latest Ubuntu
 LTS*). The script will install all required OS packages, [install Rust using
 `rustup`](https://rustup.rs/) and some additional rust programs and
-dependencies.
+dependencies. To run rackscale integration tests, you will also have to install
+the [DCM-based scheduler dependencies](https://github.com/hunhoffe/nrk-dcm-scheduler).
 
 The build dependencies can be divided into these categories
 

--- a/doc/src/development/Testing.md
+++ b/doc/src/development/Testing.md
@@ -103,6 +103,12 @@ tap interfaces and create new tap interface(s) for the test based on the
 number of hosts in the test. Then, to run the nrk instances, run.py is invoked
 with the `--no-network-setup` flag.
 
+To setup the network for a single client and server (`--workers clients+server`), run the following command:
+
+```bash
+python3 run.py --kfeatures integration-test --cmd "test=network_only" net --workers 2 --network-only
+```
+
 ### Ping
 
 A simple check is to use ping (on the host) to test the network stack

--- a/doc/src/development/Testing.md
+++ b/doc/src/development/Testing.md
@@ -94,6 +94,15 @@ vmxnet3. virtio and e1000 are available by using the respective rumpkernel
 drivers (and it's network stack). vmxnet3 is a standalone implementation that
 uses `smoltcp` for the network stack and is also capable of running in ring 0.
 
+### Network Setup
+
+The integration tests that run multiple instances of nrk require
+bridged tap interfaces. For those integration tests, the test framework calls
+run.py with the `--network-only` flag which will destroy existing conflicting
+tap interfaces and create new tap interface(s) for the test based on the
+number of hosts in the test. Then, to run the nrk instances, run.py is invoked
+with the `--no-network-setup` flag.
+
 ### Ping
 
 A simple check is to use ping (on the host) to test the network stack


### PR DESCRIPTION
Add documentation to include information needed to run rackscale integration tests.

I'm not sure if I should have created a separate rackscale documentation page and included it there, but I think it made sense to include it in existing documentation sections, as the rackscale integration tests aren't separate from other integration tests.