### PR TITLE
Rackscale benchmark cases

### DIFF
--- a/doc/src/benchmarking/Baselines.md
+++ b/doc/src/benchmarking/Baselines.md
@@ -69,3 +69,7 @@ Run:
 ```bash
 CXX=g++-4.8 CC=gcc-4.8 make qemu`
 ```
+
+# Rackscale
+
+One of the baselines for rackscale is NrOS. To run the rackscale benchmarks with corresponding NrOS baslines, run them with ```--feature baseline```.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -111,6 +111,8 @@ gdb = []
 integration-test = ["shmem", "ethernet"]
 # smoke: Shortens long running benchmarks to test just functionality.
 smoke = []
+# For rackscale tests, runs baseline NrOS. This causes the tests to take longer.
+baseline = []
 # baremetal: Compile benchmarks for running on bare-metal.
 baremetal = []
 # pre-alloc guest memory: For benchmark sensitive to VM exits.

--- a/kernel/testutils/src/builder.rs
+++ b/kernel/testutils/src/builder.rs
@@ -79,6 +79,35 @@ impl Machine {
         threads
     }
 
+    /// Return a set of cores per client to run benchmark, run fewer total iterations
+    /// and instead more with high core counts.
+    pub fn rackscale_thread_defaults_low_mid_high(&self, nclients: usize) -> Vec<usize> {
+        if cfg!(feature = "smoke") {
+            return vec![1];
+        }
+
+        let uniform_threads = self.rackscale_thread_defaults_uniform(nclients);
+        let mut threads = Vec::with_capacity(6);
+
+        for low in uniform_threads.iter().take(2) {
+            threads.push(*low);
+        }
+
+        let mid = uniform_threads.len() / 2;
+        if let Some(e) = uniform_threads.get(mid) {
+            threads.push(*e);
+        }
+
+        for high in uniform_threads.iter().rev().take(3) {
+            threads.push(*high);
+        }
+
+        threads.sort_unstable();
+        threads.dedup();
+
+        threads
+    }
+
     /// Return a set of cores to run benchmark on sampled uniform between
     /// 1..self.max_cores().
     pub fn thread_defaults_uniform(&self) -> Vec<usize> {
@@ -114,6 +143,46 @@ impl Machine {
         threads.push(max_cores / nodes);
         threads.push(max_cores);
 
+        threads.sort_unstable();
+        threads.dedup();
+
+        threads
+    }
+
+    /// Return a set of cores to run benchmark on sampled uniform between
+    /// 1..self.max_cores().
+    pub fn rackscale_thread_defaults_uniform(&self, nclients: usize) -> Vec<usize> {
+        if cfg!(feature = "smoke") {
+            return vec![1];
+        }
+
+        // Leave some extra cores for controller, ivshmem server, dcm, etc.
+        let max_cores = self.max_cores();
+        let max_cores_per_client = (max_cores - 4) / nclients;
+
+        let mut threads = Vec::with_capacity(12);
+        // On larger machines thread increments are bigger than on smaller
+        // machines:
+        let thread_incremements = if max_cores > 96 {
+            16
+        } else if max_cores > 24 {
+            8
+        } else if max_cores > 16 {
+            4
+        } else {
+            2
+        } / nclients;
+
+        for t in (0..(max_cores_per_client + 1)).step_by(thread_incremements) {
+            if t == 0 {
+                // Can't run on 0 threads
+                threads.push(t + 1);
+            } else {
+                threads.push(t);
+            }
+        }
+
+        threads.push(max_cores_per_client);
         threads.sort_unstable();
         threads.dedup();
 

--- a/kernel/testutils/src/helpers.rs
+++ b/kernel/testutils/src/helpers.rs
@@ -30,10 +30,6 @@ pub const SHMEM_SIZE: usize = 1024;
 /// Delay between invoking version of nrk in rackscale tests
 pub const CLIENT_BUILD_DELAY: u64 = 5_000;
 
-/// Benchmark configurations for rackscale
-pub const RACKSCALE_CLIENTS: &[usize] = &[1, 2, 4, 8];
-pub const RACKSCALE_CLIENTS_MAX: usize = 8;
-
 /// Sets up network interfaces and bridge for rackscale mode
 ///
 /// num_nodes includes the controller in the count. Internally this

--- a/kernel/testutils/src/helpers.rs
+++ b/kernel/testutils/src/helpers.rs
@@ -30,6 +30,10 @@ pub const SHMEM_SIZE: usize = 1024;
 /// Delay between invoking version of nrk in rackscale tests
 pub const CLIENT_BUILD_DELAY: u64 = 5_000;
 
+/// Benchmark configurations for rackscale
+pub const RACKSCALE_CLIENTS: &[usize] = &[1, 2, 4, 8];
+pub const RACKSCALE_CLIENTS_MAX: usize = 8;
+
 /// Sets up network interfaces and bridge for rackscale mode
 ///
 /// num_nodes includes the controller in the count. Internally this

--- a/lib/kpi/src/process.rs
+++ b/lib/kpi/src/process.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use x86::bits64::paging::PML4_SLOT_SIZE;
 
 /// Max number of machines supported by the process allocator.
-pub const MAX_MACHINES: usize = 8;
+pub const MAX_MACHINES: usize = 4;
 
-pub const MAX_CORES_PER_MACHINE: usize = 12;
+pub const MAX_CORES_PER_MACHINE: usize = 24;
 
 /// Max number of cores supported by the process allocator.
 pub const MAX_CORES: usize = 96; // MAX_MACHINES * MAX_CORES_PER_MACHINE;

--- a/lib/kpi/src/process.rs
+++ b/lib/kpi/src/process.rs
@@ -7,12 +7,15 @@ use serde::{Deserialize, Serialize};
 use x86::bits64::paging::PML4_SLOT_SIZE;
 
 /// Max number of machines supported by the process allocator.
-pub const MAX_MACHINES: usize = 4;
+pub const MAX_MACHINES: usize = 8;
 
-pub const MAX_CORES_PER_MACHINE: usize = 24;
+pub const MAX_CORES_PER_MACHINE: usize = 12;
 
 /// Max number of cores supported by the process allocator.
 pub const MAX_CORES: usize = 96; // MAX_MACHINES * MAX_CORES_PER_MACHINE;
+
+// Make sure the rackscale configuration respects the max cores config
+static_assertions::const_assert!(MAX_MACHINES * MAX_CORES_PER_MACHINE <= MAX_CORES);
 
 /// Offset in address-space for ELF binary relocation.
 pub const ELF_OFFSET: usize = 0x20_0000_0000;
@@ -29,7 +32,6 @@ pub const HEAP_PER_CORE_REGION: usize = 0x2_0000_0000;
 /// End of Heap memory.
 pub const HEAP_END: usize = HEAP_START + ((MAX_CORES + 1) * HEAP_PER_CORE_REGION);
 
-// TODO(rackscale): is it okay to exceed this in order to allow greater total system size?
 // Make sure that all our process regions are in the first PML4 slot. This isn't
 // really necessary for anything except benchmarking: it helps for scalability
 // benchmarks if we know that all other slots are "empty" and we don't

--- a/scripts/ci.bash
+++ b/scripts/ci.bash
@@ -24,8 +24,8 @@ RUST_TEST_THREADS=1 cargo test --test s10* -- s10_redis_benchmark_ --nocapture
 RUST_TEST_THREADS=1 cargo test --test s10* -- s10_leveldb_benchmark --nocapture
 RUST_TEST_THREADS=1 cargo test --test s10* -- s10_fxmark_bench --nocapture
 
-RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_benchmark --nocapture
-RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_latency_benchmark --nocapture
+RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_maptput_benchmark --nocapture
+RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_maplat_benchmark --nocapture
 RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_fxmark_bench --nocapture
 
 # Clone repo

--- a/scripts/ci.bash
+++ b/scripts/ci.bash
@@ -13,6 +13,8 @@ rm -f fxmark_benchmark.csv
 rm -f leveldb_benchmark.csv
 
 rm -f rackscale_shmem_vmops_benchmark.csv
+rm -f rackscale_shmem_vmops_latency_benchmark.csv
+rm -f rackscale_shmem_fxmark_benchmark.csv
 
 # For vmops: --features prealloc can improve performance further (at the expense of test duration)
 RUST_TEST_THREADS=1 cargo test --test s10* -- s10_vmops_benchmark --nocapture
@@ -23,6 +25,8 @@ RUST_TEST_THREADS=1 cargo test --test s10* -- s10_leveldb_benchmark --nocapture
 RUST_TEST_THREADS=1 cargo test --test s10* -- s10_fxmark_bench --nocapture
 
 RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_benchmark --nocapture
+RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_vmops_latency_benchmark --nocapture
+RUST_TEST_THREADS=1 cargo test --test s11* -- s11_rackscale_shmem_fxmark_bench --nocapture
 
 # Clone repo
 rm -rf gh-pages
@@ -102,7 +106,20 @@ fi
 mkdir -p ${DEPLOY_DIR}
 cp gh-pages/rackscale/vmops/index.markdown ${DEPLOY_DIR}
 mv rackscale_shmem_vmops_benchmark.csv ${DEPLOY_DIR}
+mv rackscale_shmem_vmops_latency_benchmark.csv ${DEPLOY_DIR}
 gzip ${DEPLOY_DIR}/rackscale_shmem_vmops_benchmark.csv
+gzip ${DEPLOY_DIR}/rackscale_shmem_vmops_latency_benchmark.csv
+
+# Copy rackscale memfs results
+DEPLOY_DIR="gh-pages/rackscale/memfs/${CI_MACHINE_TYPE}/${GIT_REV_CURRENT}/"
+if [ -d "${DEPLOY_DIR}" ]; then
+    # If we already have results (created the directory),
+    # we will add the new results in a subdir
+    DEPLOY_DIR=${DEPLOY_DIR}${DATE_PREFIX}
+fi
+mkdir -p ${DEPLOY_DIR}
+mv rackscale_shmem_fxmark_benchmark.csv ${DEPLOY_DIR}
+gzip ${DEPLOY_DIR}/rackscale_shmem_fxmark_benchmark.csv
 
 # Update CI history plots
 python3 gh-pages/_scripts/ci_history.py --append --machine $CI_MACHINE_TYPE


### PR DESCRIPTION
Update which test cases are run for rackscale vmops and fxmark benchmarks.
Update documentation on building the ivshmem-server
Add feature flag ```baseline``` to toggle whether NrOS baseline tests run during rackscale benchmarks.