### PR TITLE
Affinity shmem

### DIFF
--- a/doc/src/development/Testing.md
+++ b/doc/src/development/Testing.md
@@ -105,6 +105,16 @@ Benchmarks are named as such:
 * ```s10_*```: User-space applications benchmarks
 * ```s11_*```: Rackscale (distributed) benchmarks
 
+The ```s11_*``` benchmarks may be configured with two features:
+* ```baseline```: Runs NrOS configured similarly to rackscale, for comparison
+* ```affinity-shmem```: Runs the ```ivshmem-server``` using shmem with NUMA affinity.
+  This option requires preconfiguring hugetlbfs with
+  ```sudo hugeadm --create-global-mounts```,
+  having a kernel with 2MB huge pages enabled, and then also adding 1024 2MB pages per
+  node, with a command like:
+  ```echo <page-num> | sudo numactl -m <node-num> tee -a /proc/sys/vm/nr_hugepages_mempolicy```
+  The number of huge pages per node may be verified with ```numastat -m```.
+ 
 ## Network
 
 nrk has support for three network interfaces at the moment: virtio, e1000 and

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -113,6 +113,8 @@ integration-test = ["shmem", "ethernet"]
 smoke = []
 # For rackscale tests, runs baseline NrOS. This causes the tests to take longer.
 baseline = []
+# For rackscale tests, use shmem allocated with numa affinity. This requires pre-configuring the host.
+affinity-shmem = []
 # baremetal: Compile benchmarks for running on bare-metal.
 baremetal = []
 # pre-alloc guest memory: For benchmark sensitive to VM exits.

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -307,6 +307,9 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
     // form by klogger::init above, but now we do it for more ports)
     debug::init();
 
+    use crate::transport::shmem::SHMEM_INITIALIZED;
+    lazy_static::initialize(&SHMEM_INITIALIZED);
+
     // Parse memory map provided by UEFI, create an initial emergency memory
     // manager with a little bit of memory so we can do some early allocations.
     let (emanager, memory_regions) = memory::process_uefi_memory_regions();
@@ -396,8 +399,8 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
     #[cfg(feature = "rackscale")]
     {
         {
-            use crate::transport::shmem::SHMEM_DEVICE;
-            lazy_static::initialize(&SHMEM_DEVICE);
+            use crate::transport::shmem::SHMEM;
+            lazy_static::initialize(&SHMEM);
 
             if crate::CMDLINE
                 .get()
@@ -412,7 +415,7 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
                 };
 
                 // Setup to receive interrupts
-                SHMEM_DEVICE.enable_msix_vector(
+                SHMEM.devices[0].enable_msix_vector(
                     REMOTE_TLB_WORK_PENDING_SHMEM_VECTOR as usize,
                     0,
                     REMOTE_TLB_WORK_PENDING_VECTOR,

--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -307,8 +307,11 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
     // form by klogger::init above, but now we do it for more ports)
     debug::init();
 
-    use crate::transport::shmem::SHMEM_INITIALIZED;
-    lazy_static::initialize(&SHMEM_INITIALIZED);
+    #[cfg(feature = "rackscale")]
+    {
+        use crate::transport::shmem::SHMEM_INITIALIZED;
+        lazy_static::initialize(&SHMEM_INITIALIZED);
+    }
 
     // Parse memory map provided by UEFI, create an initial emergency memory
     // manager with a little bit of memory so we can do some early allocations.

--- a/kernel/src/arch/x86_64/process.rs
+++ b/kernel/src/arch/x86_64/process.rs
@@ -88,7 +88,7 @@ lazy_static! {
             let pcm = per_core_mem();
             pcm.set_mem_affinity(SHARED_AFFINITY).expect("Can't change affinity");
         } else {
-            // Get location of the logs from the controller, who will created them in shared memory
+            // Get location of the logs from the controller, who will have created them in shared memory
             use crate::arch::rackscale::get_shmem_structure::{rpc_get_shmem_structure, ShmemStructure};
 
             let mut log_ptrs = [0u64; MAX_PROCESSES];

--- a/kernel/src/arch/x86_64/rackscale/get_shmem_frames.rs
+++ b/kernel/src/arch/x86_64/rackscale/get_shmem_frames.rs
@@ -20,7 +20,7 @@ use crate::error::{KError, KResult};
 use crate::memory::backends::PhysicalPageProvider;
 use crate::memory::Frame;
 use crate::process::Pid;
-use crate::transport::shmem::{ShmemRegion, SHMEM_DEVICE};
+use crate::transport::shmem::ShmemRegion;
 
 use crate::memory::backends::AllocatorStatistics;
 

--- a/kernel/src/arch/x86_64/rackscale/processops/allocate_physical.rs
+++ b/kernel/src/arch/x86_64/rackscale/processops/allocate_physical.rs
@@ -20,7 +20,7 @@ use crate::memory::backends::PhysicalPageProvider;
 use crate::memory::{Frame, PAddr, BASE_PAGE_SIZE};
 use crate::nrproc::NrProcess;
 use crate::process::Pid;
-use crate::transport::shmem::{is_shmem_frame, ShmemRegion};
+use crate::transport::shmem::ShmemRegion;
 
 #[derive(Debug)]
 pub(crate) struct AllocatePhysicalReq {
@@ -65,10 +65,6 @@ pub(crate) fn rpc_allocate_physical(pid: Pid, size: u64, affinity: u64) -> KResu
                 size,
             };
             let frame = shmem_region.get_frame(0);
-
-            // TODO(rackscale performance): should be debug assert
-            assert!(is_shmem_frame(frame, false, false));
-
             let fid = NrProcess::<Ring3Process>::allocate_frame_to_process(pid, frame)?;
 
             // Add frame mapping to client map
@@ -127,9 +123,6 @@ pub(crate) fn handle_allocate_physical(
             .allocate_large_page()
             .expect("DCM should ensure we have a frame to allocate here.")
     };
-
-    // TODO(rackscale performance): should be debug assert
-    assert!(is_shmem_frame(frame, false, false));
 
     construct_ret(hdr, payload, Ok((dcm_node_id, frame.base.as_u64())));
     Ok(state)

--- a/kernel/src/arch/x86_64/tlb.rs
+++ b/kernel/src/arch/x86_64/tlb.rs
@@ -419,7 +419,7 @@ pub(crate) fn remote_shootdown(handles: Vec<TlbFlushHandle>) {
     use crate::arch::irq::REMOTE_TLB_WORK_PENDING_SHMEM_VECTOR;
     use crate::arch::kcb::per_core_mem;
     use crate::memory::SHARED_AFFINITY;
-    use crate::transport::shmem::SHMEM_DEVICE;
+    use crate::transport::shmem::SHMEM;
 
     let my_mtid = kpi::system::mtid_from_gtid(*crate::environment::CORE_ID);
     let my_mid = kpi::system::mid_from_gtid(*crate::environment::CORE_ID);
@@ -468,7 +468,8 @@ pub(crate) fn remote_shootdown(handles: Vec<TlbFlushHandle>) {
                 i,
                 handles[i].core_map.is_empty()
             );
-            SHMEM_DEVICE.set_doorbell(REMOTE_TLB_WORK_PENDING_SHMEM_VECTOR, i.try_into().unwrap());
+            SHMEM.devices[0]
+                .set_doorbell(REMOTE_TLB_WORK_PENDING_SHMEM_VECTOR, i.try_into().unwrap());
         }
     }
 

--- a/kernel/src/memory/mcache.rs
+++ b/kernel/src/memory/mcache.rs
@@ -283,21 +283,6 @@ impl<const BP: usize, const LP: usize> PhysicalPageProvider for MCache<BP, LP> {
         assert_eq!(frame.base % LARGE_PAGE_SIZE, 0);
         assert_eq!(frame.affinity, self.node);
 
-        // TODO(rackscale performance): should be debug only
-        #[cfg(feature = "rackscale")]
-        {
-            use crate::transport::shmem::is_shmem_frame;
-
-            // Attempt to disallow mixing shmem/not shmem
-            if self.node == SHARED_AFFINITY {
-                assert!(is_shmem_frame(frame, false, false) || is_shmem_frame(frame, false, true));
-            } else {
-                assert!(
-                    !is_shmem_frame(frame, false, false) && !is_shmem_frame(frame, false, true)
-                );
-            }
-        }
-
         self.large_page_addresses
             .try_push(frame.base)
             .map_err(|_e| KError::CacheFull)

--- a/kernel/src/memory/shmemalloc.rs
+++ b/kernel/src/memory/shmemalloc.rs
@@ -11,10 +11,6 @@ use core::ptr::NonNull;
 
 use crate::arch::kcb::per_core_mem;
 use crate::memory::SHARED_AFFINITY;
-use crate::transport::shmem::is_shmem_addr;
-
-//use crate::arch::kcb::per_core_mem;
-//use crate::memory::per_core::SHARED_AFFINITY;
 
 #[derive(Clone)]
 pub(crate) struct ShmemAlloc();
@@ -34,13 +30,6 @@ unsafe impl Allocator for ShmemAlloc {
         let ptr = unsafe { alloc(layout) };
 
         let ret = if !ptr.is_null() {
-            // TODO(rackscale performance): should probably be debug_assert
-            assert!(
-                is_shmem_addr(ptr as u64, true, true),
-                "allocated pointer ({}) isn't a shmem address",
-                ptr as u64,
-            );
-
             Ok(unsafe {
                 let nptr = NonNull::new_unchecked(ptr);
                 NonNull::slice_from_raw_parts(nptr, layout.size())
@@ -59,9 +48,6 @@ unsafe impl Allocator for ShmemAlloc {
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        // TODO(rackscale performance): should probably be debug_assert
-        assert!(is_shmem_addr(ptr.as_ptr() as u64, true, true));
-
         let affinity = {
             // We want to allocate the logs in shared memory
             let pcm = per_core_mem();

--- a/kernel/src/pci.rs
+++ b/kernel/src/pci.rs
@@ -59,7 +59,7 @@ pub(crate) fn claim_devices(vendor_id: u16, device_id: u16) -> Vec<PciDevice> {
             }
         }
     }
-    return devices;
+    devices
 }
 
 pub(crate) fn init() {

--- a/kernel/tests/s10_benchmarks.rs
+++ b/kernel/tests/s10_benchmarks.rs
@@ -133,7 +133,7 @@ fn s10_vmops_benchmark() {
             .cmd(kernel_cmdline.as_str());
 
         if cfg!(feature = "smoke") {
-            cmdline = cmdline.memory(10 * 1024);
+            cmdline = cmdline.memory(16 * 1024);
         } else {
             cmdline = cmdline.memory(48 * 1024);
         }

--- a/kernel/tests/s10_benchmarks.rs
+++ b/kernel/tests/s10_benchmarks.rs
@@ -478,7 +478,7 @@ fn s10_fxmark_benchmark() {
                 let kernel_cmdline = format!("initargs={}X{}X{}", cores, of, benchmark);
                 let mut cmdline = RunnerArgs::new_with_build("userspace-smp", &build)
                     .memory(1024)
-                    .timeout(num_microbenchs * (25_000 + cores as u64 * 1000))
+                    .timeout(num_microbenchs * (25_000 + cores as u64 * 2000))
                     .cores(machine.max_cores())
                     .setaffinity(Vec::new())
                     .cmd(kernel_cmdline.as_str());

--- a/kernel/tests/s11_rackscale_benchmarks.rs
+++ b/kernel/tests/s11_rackscale_benchmarks.rs
@@ -141,8 +141,13 @@ fn rackscale_fxmark_benchmark(is_shmem: bool) {
                     );
 
                     let (shmem_socket, shmem_file) = get_shmem_names(None);
+                    let shmem_affinity = if cfg!(feature = "affinity-shmem") {
+                        Some(0)
+                    } else {
+                        None
+                    };
                     let mut shmem_server =
-                        spawn_shmem_server(&shmem_socket, &shmem_file, shmem_size, Some(0))
+                        spawn_shmem_server(&shmem_socket, &shmem_file, shmem_size, shmem_affinity)
                             .expect("Failed to start shmem server");
 
                     let mut cmdline_baseline =
@@ -250,14 +255,15 @@ fn rackscale_fxmark_benchmark(is_shmem: bool) {
                 let mut shmem_sockets = Vec::new();
                 let mut shmem_servers = Vec::new();
                 for i in 0..(num_clients + 1) {
+                    let shmem_affinity = if cfg!(feature = "affinity-shmem") {
+                        Some(placement_cores[i].0)
+                    } else {
+                        None
+                    };
                     let (shmem_socket, shmem_file) = get_shmem_names(Some(i));
-                    let shmem_server = spawn_shmem_server(
-                        &shmem_socket,
-                        &shmem_file,
-                        shmem_size,
-                        Some(placement_cores[i].0),
-                    )
-                    .expect("Failed to start shmem server");
+                    let shmem_server =
+                        spawn_shmem_server(&shmem_socket, &shmem_file, shmem_size, shmem_affinity)
+                            .expect("Failed to start shmem server");
                     shmem_sockets.push(shmem_socket);
                     shmem_servers.push(shmem_server);
                 }
@@ -570,9 +576,18 @@ fn rackscale_vmops_benchmark(is_shmem: bool, benchtype: VMOpsBench) {
             );
 
             let (shmem_socket, shmem_file) = get_shmem_names(None);
-            let mut shmem_server =
-                spawn_shmem_server(&shmem_socket, &shmem_file, baseline_shmem_size, Some(0))
-                    .expect("Failed to start shmem server");
+            let shmem_affinity = if cfg!(feature = "affinity-shmem") {
+                Some(0)
+            } else {
+                None
+            };
+            let mut shmem_server = spawn_shmem_server(
+                &shmem_socket,
+                &shmem_file,
+                baseline_shmem_size,
+                shmem_affinity,
+            )
+            .expect("Failed to start shmem server");
 
             let baseline_cmdline = format!("initargs={}", cores);
             let baseline_file_name = file_name.clone();
@@ -693,14 +708,15 @@ fn rackscale_vmops_benchmark(is_shmem: bool, benchtype: VMOpsBench) {
         let mut shmem_sockets = Vec::new();
         let mut shmem_servers = Vec::new();
         for i in 0..(num_clients + 1) {
+            let shmem_affinity = if cfg!(feature = "affinity-shmem") {
+                Some(placement_cores[i].0)
+            } else {
+                None
+            };
             let (shmem_socket, shmem_file) = get_shmem_names(Some(i));
-            let shmem_server = spawn_shmem_server(
-                &shmem_socket,
-                &shmem_file,
-                shmem_size,
-                Some(placement_cores[i].0),
-            )
-            .expect("Failed to start shmem server");
+            let shmem_server =
+                spawn_shmem_server(&shmem_socket, &shmem_file, shmem_size, shmem_affinity)
+                    .expect("Failed to start shmem server");
             shmem_sockets.push(shmem_socket);
             shmem_servers.push(shmem_server);
         }

--- a/kernel/testutils/src/helpers.rs
+++ b/kernel/testutils/src/helpers.rs
@@ -26,7 +26,7 @@ pub const DHCP_ACK_MATCH_NRK2: &'static str = "DHCPACK on 172.31.0.11 to 56:b4:4
 /// Default shmem region size (in MB)
 pub const SHMEM_SIZE: usize = 1024;
 /// Created by `hugeadm --create-global-mounts`
-const SHMEM_PATH: &'static str = "/var/lib/hugetlbfs/global/pagesize-2MB";
+const SHMEM_AFFINITY_PATH: &'static str = "/var/lib/hugetlbfs/global/pagesize-2MB";
 
 /// Delay between invoking version of nrk in rackscale tests
 pub const CLIENT_BUILD_DELAY: u64 = 5_000;
@@ -52,15 +52,20 @@ pub fn setup_network(num_nodes: usize) {
 }
 
 pub fn get_shmem_names(id: Option<usize>) -> (String, String) {
+    let shmem_path = if cfg!(feature = "affinity-shmem") {
+        SHMEM_AFFINITY_PATH
+    } else {
+        "."
+    };
     if let Some(shmemid) = id {
         (
             format!("ivshmem-socket{}", shmemid),
-            format!("{}/ivshmem-file{}", SHMEM_PATH, shmemid),
+            format!("{}/ivshmem-file{}", shmem_path, shmemid),
         )
     } else {
         (
             format!("ivshmem-socket{}", ""),
-            format!("{}/ivshmem-file{}", SHMEM_PATH, ""),
+            format!("{}/ivshmem-file{}", shmem_path, ""),
         )
     }
 }

--- a/scripts/generic-setup.sh
+++ b/scripts/generic-setup.sh
@@ -40,7 +40,7 @@ function install_run_dependencies()
         $APT install -y qemu qemu-kvm qemu-system-x86 sshpass hwloc libhwloc-dev numactl libevent-dev bridge-utils > /dev/null
 
         # nrk integration-test dependencies
-        $APT install -y isc-dhcp-server socat netcat-openbsd redis-tools net-tools graphviz tcpdump > /dev/null
+        $APT install -y isc-dhcp-server socat netcat-openbsd redis-tools net-tools graphviz tcpdump libhugetlbfs-bin > /dev/null
     fi
 }
 


### PR DESCRIPTION
This PR adds support for huge-page backed affinity shmem (by using a custom ```ivshmem-server```) and also multiple ivshmem devices. The idea is that each device may provide shmem with a set NUMA affinity. Details on the ```ivshmem-server``` are here: https://github.com/hunhoffe/qemu/pull/1

A subsequent PR will be made to place some rackscale data structures in more appropriate shmem regions.

By default, affinity shmem is turned off - and is only configured for rackscale benchmarks. However, it may be switched on by supplying ```--feature affinity-shmem``` to the ```s11_rackscale_benchmark``` tests. It is switched off by default, because it did not seem like the best idea to configure hugepages on the fly for testing.

Before running, ensure the ho stkernel supports 2MB hugepages, and create the mounts with:
```bash
hugeadm --create-global-mounts
```
Hugepages must be pre-allocated on each NUMA node (1024 2MB pages per node), with a command similar to below:
```bash
echo <page-num> | sudo numactl -m <node-num> tee -a /proc/sys/vm/nr_hugepages_mempolicy
```
I've documented this in the testing/benchmark documentation.

Here is an example run from the rackscale fxmark test with the ```--feature affinity-shmem``` set:
```
	Running fxmark test mixX0 with 8 total core(s), 1 client(s) (cores_per_client=8) and 24 open files
Invoke shmem server: ivshmem-server -F -S ivshmem-socket0 -m /var/lib/hugetlbfs/global/pagesize-2MB/ivshmem-file0 -l 1024M -n 2 -a 0
Invoke shmem server: ivshmem-server -F -S ivshmem-socket1 -m /var/lib/hugetlbfs/global/pagesize-2MB/ivshmem-file1 -l 1024M -n 2 -a 1
Invoke DCM: java -jar ../target/dcm-scheduler.jar -r 1 -p 5
Invoke QEMU: "python3" "run.py" "--kfeatures" "integration-test,shmem,ethernet,rackscale" "--ufeatures" "fxmark" "--mods" "init" "--release" "--cmd" "log=info test=userspace-smp mode=controller transport=shmem" "--nic" "vmxnet3" "--qemu-cores" "1" "--qemu-nodes" "0" "--qemu-memory" "73728" "--qemu-ivshmem" "1024,1024" "--qemu-shmem-path" "ivshmem-socket0,ivshmem-socket1" "--tap" "tap0" "--qemu-affinity" "[0]" "net" "--workers" "2" "--no-network-setup"
Invoke QEMU: "python3" "run.py" "--kfeatures" "integration-test,shmem,ethernet,rackscale" "--ufeatures" "fxmark" "--mods" "init" "--release" "--cmd" "log=info test=userspace-smp mode=client transport=shmem initargs=8X24XmixX0" "--nic" "vmxnet3" "--qemu-cores" "8" "--qemu-nodes" "0" "--qemu-memory" "73728" "--qemu-ivshmem" "1024,1024" "--qemu-shmem-path" "ivshmem-socket0,ivshmem-socket1" "--tap" "tap2" "--qemu-affinity" "[1, 5, 9, 13, 17, 21, 25, 29]" "--nobuild" "net" "--workers" "2" "--no-network-setup"
Terminating.
```

```ishmem-server``` 0 has affinity 0 and will be used by the controller . ```ivshmem-server``` 1 has affinity 1 and will be used by the data kernel. Generally, ```ishmem-server``` #s map to machine ids. For invoking ```run.py```, ```--qemu-ivshmem``` is now a list of sizes and ```--qemu-shmem-path``` is now a list of paths. The lists are zipped when creating devices, with the first in the list is set to have the lowest device ID, with device IDs assigned sequentially, and these device IDs are then used internally by the OS to determine which device contains "their" memory. For the controller, it is assigned core 0, which has numa affinity 0 (matching the ```ivshmem-server``` 0 affinity). The data kernel is assigned cores 1, 5, 9, .... which have affinity 1, matching ```ivshmem-server``` 1.