### PR TITLE
Multi-core Controller and Rackscale State Cleanup

### DIFF
--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -226,6 +226,13 @@ pub(crate) fn start_app_core(args: Arc<AppCoreArgs>, initialized: &AtomicBool) {
     // Signals to BSP core that we're done initializing.
     initialized.store(true, Ordering::SeqCst);
 
+    #[cfg(feature = "rackscale")]
+    if crate::CMDLINE
+        .get()
+        .map_or(false, |c| c.mode == crate::cmdline::Mode::Controller)
+    {
+        crate::arch::rackscale::controller::run()
+    }
     crate::scheduler::schedule()
 }
 
@@ -411,7 +418,7 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
             {
                 use crate::arch::rackscale::controller_state::CONTROLLER_SHMEM_CACHES;
                 lazy_static::initialize(&CONTROLLER_SHMEM_CACHES);
-                lazy_static::initialize(&crate::arch::rackscale::dcm::DCM_INTERFACE);
+                lazy_static::initialize(&crate::arch::rackscale::dcm::DCM_CLIENT);
             } else {
                 use crate::arch::irq::{
                     REMOTE_TLB_WORK_PENDING_SHMEM_VECTOR, REMOTE_TLB_WORK_PENDING_VECTOR,

--- a/kernel/src/arch/x86_64/process.rs
+++ b/kernel/src/arch/x86_64/process.rs
@@ -1433,14 +1433,14 @@ impl Process for Ring3Process {
                     MapAction::user() | MapAction::write(),
                 )
                 .expect("Can't map user-space executor memory.");
-            log::info!(
+            log::debug!(
                 "executor space base expanded {:#x} size: {} end {:#x}",
                 self.executor_offset,
                 memory.size(),
                 self.executor_offset + memory.size()
             );
         } else {
-            log::info!(
+            log::debug!(
                 "skipping executor space vspace mapping for mid={:?} on mid={:?} {:#x} size: {} end {:#x}",
                 mid,
                 *crate::environment::MACHINE_ID,
@@ -1460,7 +1460,7 @@ impl Process for Ring3Process {
                     MapAction::user() | MapAction::write(),
                 )
                 .expect("Can't map user-space executor memory.");
-            info!(
+            log::debug!(
                 "executor space base expanded {:#x} size: {} end {:#x}",
                 self.executor_offset,
                 memory.size(),

--- a/kernel/src/arch/x86_64/rackscale/client_state.rs
+++ b/kernel/src/arch/x86_64/rackscale/client_state.rs
@@ -32,7 +32,6 @@ pub(crate) struct ClientState {
     pub(crate) rpc_client: Arc<Mutex<Client>>,
 
     /// Used to store shmem affinity base pages
-    /// TODO(rackscale): is the box necessary?
     pub(crate) affinity_base_pages: ArrayVec<Arc<Mutex<Box<dyn MemManager + Send>>>, MAX_MACHINES>,
 
     /// Used to store base pages allocated to a process

--- a/kernel/src/arch/x86_64/rackscale/controller.rs
+++ b/kernel/src/arch/x86_64/rackscale/controller.rs
@@ -5,6 +5,7 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 use arrayvec::ArrayVec;
 use core::cell::Cell;
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use smoltcp::time::Instant;
 
 use rpc::api::RPCServer;
@@ -12,6 +13,9 @@ use rpc::rpc::RPCType;
 use rpc::server::Server;
 use rpc::transport::TCPTransport;
 
+use crate::arch::rackscale::dcm::{
+    DCMOps, DCM_CLIENT_REGISTRAR, DCM_SERVER_PORT, NODE_ASSIGNMENT_HANDLER,
+};
 use crate::arch::MAX_MACHINES;
 use crate::cmdline::Transport;
 use crate::transport::ethernet::ETHERNET_IFACE;
@@ -21,84 +25,117 @@ use super::*;
 
 pub(crate) const CONTROLLER_PORT_BASE: u16 = 6970;
 
+static ClientReadyCount: AtomicU64 = AtomicU64::new(0);
+static DCMServerReady: AtomicBool = AtomicBool::new(false);
+
 /// Controller main method
 pub(crate) fn run() {
-    // Initialize one server per client
-    let num_clients = *crate::environment::NUM_MACHINES - 1;
-    let mut servers: ArrayVec<Server, MAX_MACHINES> = ArrayVec::new();
+    let mid = *crate::environment::CORE_ID;
 
-    if crate::CMDLINE
+    // Initialize one server per controller thread
+    let mut server = if crate::CMDLINE
         .get()
         .map_or(false, |c| c.transport == Transport::Ethernet)
     {
-        for mid in 0..num_clients {
-            let transport = Box::new(
-                TCPTransport::new(
-                    None,
-                    CONTROLLER_PORT_BASE + mid as u16,
-                    Arc::clone(&ETHERNET_IFACE),
-                )
-                .expect("Failed to create TCP transport"),
-            );
-            let mut server = Server::new(transport);
-            register_rpcs(&mut server);
-            servers.push(server);
-        }
+        let transport = Box::new(
+            TCPTransport::new(
+                None,
+                CONTROLLER_PORT_BASE + mid as u16 - 1,
+                Arc::clone(&ETHERNET_IFACE),
+            )
+            .expect("Failed to create TCP transport"),
+        );
+        let mut server = Server::new(transport);
+        register_rpcs(&mut server);
+        server
     } else if crate::CMDLINE
         .get()
         .map_or(false, |c| c.transport == Transport::Shmem)
     {
-        for mid in 1..=num_clients {
-            let transport = Box::new(
-                create_shmem_transport(mid.try_into().unwrap())
-                    .expect("Failed to create shmem transport"),
-            );
+        let transport = Box::new(
+            create_shmem_transport(mid.try_into().unwrap())
+                .expect("Failed to create shmem transport"),
+        );
 
-            let mut server = Server::new(transport);
-            register_rpcs(&mut server);
-            servers.push(server);
-        }
+        let mut server = Server::new(transport);
+        register_rpcs(&mut server);
+        server
     } else {
         unreachable!("No supported transport layer specified in kernel argument");
-    }
+    };
 
-    for server in servers.iter_mut() {
-        server
-            .add_client(&CLIENT_REGISTRAR)
-            .expect("Failed to connect to remote server");
+    // Wait for all clients to connect before fulfilling any RPCs.
+    while !DCMServerReady.load(Ordering::SeqCst) {}
+
+    server
+        .add_client(&CLIENT_REGISTRAR)
+        .expect("Failed to accept client");
+
+    ClientReadyCount.fetch_add(1, Ordering::SeqCst);
+
+    // Wait for all clients to connect before fulfilling any RPCs.
+    while ClientReadyCount.load(Ordering::SeqCst) != (*crate::environment::NUM_MACHINES - 1) as u64
+    {
     }
 
     #[cfg(feature = "test-controller-shmem-alloc")]
     {
-        // We don't put this in integration.rs because it must happen midway-through controller initialization
-        use crate::arch::debug::shutdown;
-        use crate::arch::rackscale::dcm::affinity_alloc::dcm_affinity_alloc;
-        use crate::memory::shmem_affinity::mid_to_shmem_affinity;
-        use crate::transport::shmem::SHMEM;
-        use crate::ExitReason;
+        if mid == 1 {
+            // We don't put this in integration.rs because it must happen midway-through controller initialization
+            use crate::arch::debug::shutdown;
+            use crate::arch::rackscale::dcm::affinity_alloc::dcm_affinity_alloc;
+            use crate::memory::shmem_affinity::mid_to_shmem_affinity;
+            use crate::transport::shmem::SHMEM;
+            use crate::ExitReason;
 
-        let LARGE_PAGES_PER_CLIENT = 2;
+            let LARGE_PAGES_PER_CLIENT = 2;
+            let num_clients = *crate::environment::NUM_MACHINES - 1;
 
-        for mid in 1..(num_clients + 1) {
-            let regions = dcm_affinity_alloc(mid, LARGE_PAGES_PER_CLIENT)
-                .expect("Controller failed to allocate!");
-            assert!(regions.len() == LARGE_PAGES_PER_CLIENT);
-            for i in 0..LARGE_PAGES_PER_CLIENT {
-                assert!(
-                    regions[i].base >= SHMEM.devices[mid].region.base.as_u64()
-                        && regions[i].base
-                            < SHMEM.devices[mid].region.base.as_u64()
-                                + SHMEM.devices[mid].region.size as u64
-                );
-                assert!(regions[i].affinity == mid_to_shmem_affinity(mid));
+            for test_mid in 1..(num_clients + 1) {
+                let regions = dcm_affinity_alloc(test_mid, LARGE_PAGES_PER_CLIENT)
+                    .expect("Controller failed to allocate!");
+                assert!(regions.len() == LARGE_PAGES_PER_CLIENT);
+                for i in 0..LARGE_PAGES_PER_CLIENT {
+                    assert!(
+                        regions[i].base >= SHMEM.devices[test_mid].region.base.as_u64()
+                            && regions[i].base
+                                < SHMEM.devices[test_mid].region.base.as_u64()
+                                    + SHMEM.devices[test_mid].region.size as u64
+                    );
+                    assert!(regions[i].affinity == mid_to_shmem_affinity(test_mid));
+                }
             }
+            log::info!("controller_shmem_alloc OK");
+            shutdown(ExitReason::Ok);
         }
-        log::info!("controller_shmem_alloc OK");
-        shutdown(ExitReason::Ok);
     }
 
     // Start running the RPC server
-    log::info!("Starting RPC server!");
+    log::info!("Starting RPC server for client {:?}!", mid);
+    loop {
+        let _handled = server
+            .try_handle()
+            .expect("Controller failed to handle RPC");
+    }
+}
+
+pub(crate) fn poll_interface() {
+    // Create RPC server connecting to DCM
+    let transport = Box::try_new(
+        TCPTransport::new(None, DCM_SERVER_PORT, Arc::clone(&ETHERNET_IFACE))
+            .expect("Failed to create TCP transport"),
+    )
+    .expect("Out of memory during init");
+    let mut server = Server::new(transport);
+    server
+        .register(DCMOps::NodeAssignment as RPCType, &NODE_ASSIGNMENT_HANDLER)
+        .unwrap();
+    let _ = server.add_client(&DCM_CLIENT_REGISTRAR).unwrap();
+    log::info!("Added DCM server RPC client!");
+
+    // Now that server is ready, the clients may be accepted.
+    DCMServerReady.store(true, Ordering::SeqCst);
+
     loop {
         match ETHERNET_IFACE.lock().poll(Instant::from_millis(
             rawtime::duration_since_boot().as_millis() as i64,
@@ -109,12 +146,7 @@ pub(crate) fn run() {
             }
         }
 
-        // Try to handle an RPC request
-        for server in servers.iter_mut() {
-            let _handled = server
-                .try_handle()
-                .expect("Controller failed to handle RPC");
-        }
+        let _ = server.try_handle();
     }
 }
 

--- a/kernel/src/arch/x86_64/rackscale/dcm/affinity_alloc.rs
+++ b/kernel/src/arch/x86_64/rackscale/dcm/affinity_alloc.rs
@@ -90,8 +90,7 @@ pub(crate) fn dcm_affinity_alloc(
     // Take the frames from the shmem allocator belonging to the requested mid
     let mut regions = Vec::<ShmemRegion>::new();
     {
-        let mut shmem_managers = SHMEM_MEMSLICE_ALLOCATORS.lock();
-        let mut manager = &mut shmem_managers[mid - 1];
+        let mut manager = &mut SHMEM_MEMSLICE_ALLOCATORS[mid - 1].lock();
         for _i in 0..num_memslices {
             let frame = manager
                 .allocate_large_page()

--- a/kernel/src/arch/x86_64/rackscale/dcm/affinity_alloc.rs
+++ b/kernel/src/arch/x86_64/rackscale/dcm/affinity_alloc.rs
@@ -10,7 +10,7 @@ use rpc::RPCClient;
 use super::super::controller_state::SHMEM_MEMSLICE_ALLOCATORS;
 use super::super::get_shmem_frames::ShmemRegion;
 use super::super::kernelrpc::*;
-use super::{DCMOps, DCM_INTERFACE};
+use super::{DCMOps, DCM_CLIENT};
 use crate::error::{KError, KResult};
 use crate::memory::backends::PhysicalPageProvider;
 use crate::memory::shmem_affinity::mid_to_shmem_affinity;
@@ -74,7 +74,7 @@ pub(crate) fn dcm_affinity_alloc(
     let mut res = AffinityAllocRes { can_satisfy: false };
 
     // Ask DCM to make sure we can safely take from the shmem allocators
-    DCM_INTERFACE.lock().client.call(
+    DCM_CLIENT.lock().call(
         DCMOps::AffinityAlloc as RPCType,
         unsafe { &[req.as_bytes()] },
         unsafe { &mut [res.as_mut_bytes()] },

--- a/kernel/src/arch/x86_64/rackscale/dcm/node_registration.rs
+++ b/kernel/src/arch/x86_64/rackscale/dcm/node_registration.rs
@@ -5,7 +5,7 @@ use kpi::system::MachineId;
 use rpc::rpc::RPCType;
 use rpc::RPCClient;
 
-use super::{DCMOps, DCM_INTERFACE};
+use super::{DCMOps, DCM_CLIENT};
 
 #[derive(Debug, Default)]
 #[repr(C)]
@@ -60,9 +60,8 @@ pub(crate) fn dcm_register_node(mid: MachineId, cores: u64, memslices: u64) -> b
 
     // Send call, get allocation response in return
     {
-        DCM_INTERFACE
+        DCM_CLIENT
             .lock()
-            .client
             .call(
                 DCMOps::RegisterNode as RPCType,
                 unsafe { &[req.as_bytes()] },

--- a/kernel/src/arch/x86_64/rackscale/dcm/resource_release.rs
+++ b/kernel/src/arch/x86_64/rackscale/dcm/resource_release.rs
@@ -5,7 +5,7 @@ use kpi::system::MachineId;
 use rpc::rpc::RPCType;
 use rpc::RPCClient;
 
-use super::{DCMOps, DCM_INTERFACE};
+use super::{DCMOps, DCM_CLIENT};
 
 #[derive(Debug, Default)]
 #[repr(C)]
@@ -61,9 +61,8 @@ pub(crate) fn dcm_resource_release(mid: MachineId, pid: usize, is_core: bool) ->
 
     // Send call, get allocation response in return
     {
-        DCM_INTERFACE
+        DCM_CLIENT
             .lock()
-            .client
             .call(
                 DCMOps::ResourceRelease as RPCType,
                 unsafe { &[req.as_bytes()] },

--- a/kernel/src/arch/x86_64/rackscale/fileops/close.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/close.rs
@@ -12,7 +12,6 @@ use crate::error::{KError, KResult};
 use crate::fs::cnrfs;
 use crate::fs::fd::FileDescriptor;
 
-use super::super::controller_state::ControllerState;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
 use super::FileIO;
@@ -59,11 +58,7 @@ pub(crate) fn rpc_close(pid: usize, fd: FileDescriptor) -> KResult<(u64, u64)> {
 }
 
 // RPC Handler function for close() RPCs in the controller
-pub(crate) fn handle_close(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_close(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Decode request
     let ret = if let Some((req, _)) = unsafe { decode::<CloseReq>(payload) } {
         log::debug!("Close(pid={:?}), fd={:?}", req.pid, req.fd);
@@ -73,5 +68,5 @@ pub(crate) fn handle_close(
         Err(KError::from(RPCError::MalformedRequest))
     };
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/delete.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/delete.rs
@@ -13,7 +13,6 @@ use crate::error::{KError, KResult};
 use crate::fallible_string::TryString;
 use crate::fs::cnrfs;
 
-use super::super::controller_state::ControllerState;
 use super::super::fileops::get_str_from_payload;
 use super::super::kernelrpc::*;
 use super::FileIO;
@@ -57,18 +56,14 @@ pub(crate) fn rpc_delete(pid: usize, pathname: String) -> KResult<(u64, u64)> {
 }
 
 // RPC Handler function for delete() RPCs in the controller
-pub(crate) fn handle_delete(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_delete(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Parse request
     let pid = match unsafe { decode::<DeleteReq>(payload) } {
         Some((req, _)) => req.pid,
         None => {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         }
     };
 
@@ -80,5 +75,5 @@ pub(crate) fn handle_delete(
     .and_then(|path_string| cnrfs::MlnrKernelNode::file_delete(pid, path_string));
 
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/getinfo.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/getinfo.rs
@@ -13,7 +13,6 @@ use crate::error::{KError, KResult};
 use crate::fallible_string::TryString;
 use crate::fs::cnrfs;
 
-use super::super::controller_state::ControllerState;
 use super::super::fileops::get_str_from_payload;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
@@ -56,18 +55,14 @@ pub(crate) fn rpc_getinfo<P: AsRef<[u8]> + Debug>(pid: usize, name: P) -> KResul
 }
 
 // RPC Handler function for getinfo() RPCs in the controller
-pub(crate) fn handle_getinfo(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_getinfo(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Parse request
     let pid = match unsafe { decode::<GetInfoReq>(payload) } {
         Some((req, _)) => req.pid,
         None => {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         }
     };
 
@@ -80,5 +75,5 @@ pub(crate) fn handle_getinfo(
 
     // Construct results from return data
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/mkdir.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/mkdir.rs
@@ -12,7 +12,6 @@ use kpi::io::FileModes;
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
 use super::super::fileops::get_str_from_payload;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
@@ -64,18 +63,14 @@ pub(crate) fn rpc_mkdir<P: AsRef<[u8]> + Debug>(
 }
 
 // RPC Handler function for close() RPCs in the controller
-pub(crate) fn handle_mkdir(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_mkdir(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Parse request
     let (pid, modes) = match unsafe { decode::<MkDirReq>(payload) } {
         Some((req, _)) => (req.pid, req.modes),
         None => {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         }
     };
 
@@ -88,5 +83,5 @@ pub(crate) fn handle_mkdir(
 
     // Call mkdir function and send result
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/open.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/open.rs
@@ -11,7 +11,6 @@ use kpi::io::{FileFlags, FileModes};
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
 use super::super::fileops::get_str_from_payload;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
@@ -75,11 +74,7 @@ fn rpc_open_create<P: AsRef<[u8]> + Debug>(
 }
 
 // RPC Handler function for open() RPCs in the controller
-pub(crate) fn handle_open(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_open(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Decode request
     let (pid, flags, modes) = match unsafe { decode::<OpenReq>(payload) } {
         Some((req, _)) => {
@@ -94,7 +89,7 @@ pub(crate) fn handle_open(
         None => {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         }
     };
 
@@ -106,5 +101,5 @@ pub(crate) fn handle_open(
     .and_then(|path_string| cnrfs::MlnrKernelNode::map_fd(pid, path_string, flags, modes));
 
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/rename.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/rename.rs
@@ -11,7 +11,6 @@ use core2::io::Write;
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
 use super::super::fileops::get_str_from_payload;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
@@ -66,18 +65,14 @@ pub(crate) fn rpc_rename<P: AsRef<[u8]> + Debug>(
 }
 
 // RPC Handler function for rename() RPCs in the controller
-pub(crate) fn handle_rename(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_rename(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Decode request
     let (pid, oldname_len) = match unsafe { decode::<RenameReq>(payload) } {
         Some((req, _)) => (req.pid, req.oldname_len as usize),
         None => {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         }
     };
 
@@ -101,5 +96,5 @@ pub(crate) fn handle_rename(
         (Err(e), _) => construct_error_ret(hdr, payload, KError::from(e)),
         (_, Err(e)) => construct_error_ret(hdr, payload, KError::from(e)),
     }
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/fileops/rw.rs
+++ b/kernel/src/arch/x86_64/rackscale/fileops/rw.rs
@@ -13,7 +13,6 @@ use kpi::FileOperation;
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
 use super::FileIO;
@@ -170,11 +169,7 @@ pub(crate) fn rpc_readat(
 }
 
 // RPC Handler function for read() RPCs in the controller
-pub(crate) fn handle_read(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_read(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Extract data needed from the request
     let fd;
     let len;
@@ -202,7 +197,7 @@ pub(crate) fn handle_read(
     } else {
         log::error!("Invalid payload for request: {:?}", hdr);
         construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-        return Ok(state);
+        return Ok(());
     }
 
     let ret = cnrfs::MlnrKernelNode::file_read(
@@ -214,15 +209,11 @@ pub(crate) fn handle_read(
 
     // Construct return
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }
 
 // RPC Handler function for write() RPCs in the controller
-pub(crate) fn handle_write(
-    hdr: &mut RPCHeader,
-    payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_write(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError> {
     // Decode request
     let ret = if let Some((req, remaining)) = unsafe { decode::<RWReq>(payload) } {
         log::debug!(
@@ -250,5 +241,5 @@ pub(crate) fn handle_write(
         Err(KError::from(RPCError::MalformedRequest))
     };
     construct_ret(hdr, payload, ret);
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/get_shmem_structure.rs
+++ b/kernel/src/arch/x86_64/rackscale/get_shmem_structure.rs
@@ -14,7 +14,6 @@ use rpc::rpc::*;
 use rpc::RPCClient;
 
 use super::client_state::CLIENT_STATE;
-use super::controller_state::ControllerState;
 use super::kernelrpc::*;
 use crate::arch::kcb::per_core_mem;
 use crate::arch::process::{Ring3Process, PROCESS_LOGS};
@@ -101,8 +100,7 @@ pub(crate) fn rpc_get_shmem_structure(
 pub(crate) fn handle_get_shmem_structure(
     hdr: &mut RPCHeader,
     mut payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+) -> Result<(), RPCError> {
     log::debug!("Handling get_shmem_structure()");
 
     // Decode request
@@ -112,7 +110,7 @@ pub(crate) fn handle_get_shmem_structure(
         } else {
             log::error!("Invalid payload for request: {:?}", hdr);
             construct_error_ret(hdr, payload, KError::from(RPCError::MalformedRequest));
-            return Ok(state);
+            return Ok(());
         };
 
     // We want to allocate clones of the log arcs in shared memory
@@ -182,5 +180,5 @@ pub(crate) fn handle_get_shmem_structure(
             .expect("Can't change affinity");
     }
 
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/mod.rs
+++ b/kernel/src/arch/x86_64/rackscale/mod.rs
@@ -26,40 +26,37 @@ pub(crate) use self::kernelrpc::KernelRpc;
 
 pub(crate) use self::client_state::CLIENT_STATE;
 
-use self::controller_state::ControllerState;
 use self::registration::register_client;
 
 // Re-export client registration
-pub(crate) const CLIENT_REGISTRAR: RegistrationHandler<ControllerState> = register_client;
+pub(crate) const CLIENT_REGISTRAR: RegistrationHandler = register_client;
 
 // Re-export handlers: file operations
-pub(crate) const CLOSE_HANDLER: RPCHandler<ControllerState> = fileops::close::handle_close;
-pub(crate) const DELETE_HANDLER: RPCHandler<ControllerState> = fileops::delete::handle_delete;
-pub(crate) const GETINFO_HANDLER: RPCHandler<ControllerState> = fileops::getinfo::handle_getinfo;
-pub(crate) const MKDIR_HANDLER: RPCHandler<ControllerState> = fileops::mkdir::handle_mkdir;
-pub(crate) const OPEN_HANDLER: RPCHandler<ControllerState> = fileops::open::handle_open;
-pub(crate) const RENAME_HANDLER: RPCHandler<ControllerState> = fileops::rename::handle_rename;
-pub(crate) const READ_HANDLER: RPCHandler<ControllerState> = fileops::rw::handle_read;
-pub(crate) const WRITE_HANDLER: RPCHandler<ControllerState> = fileops::rw::handle_write;
+pub(crate) const CLOSE_HANDLER: RPCHandler = fileops::close::handle_close;
+pub(crate) const DELETE_HANDLER: RPCHandler = fileops::delete::handle_delete;
+pub(crate) const GETINFO_HANDLER: RPCHandler = fileops::getinfo::handle_getinfo;
+pub(crate) const MKDIR_HANDLER: RPCHandler = fileops::mkdir::handle_mkdir;
+pub(crate) const OPEN_HANDLER: RPCHandler = fileops::open::handle_open;
+pub(crate) const RENAME_HANDLER: RPCHandler = fileops::rename::handle_rename;
+pub(crate) const READ_HANDLER: RPCHandler = fileops::rw::handle_read;
+pub(crate) const WRITE_HANDLER: RPCHandler = fileops::rw::handle_write;
 
 // Re-export handdlers: process operations
-pub(crate) const REQUEST_CORE_HANDLER: RPCHandler<ControllerState> =
-    processops::request_core::handle_request_core;
-pub(crate) const ALLOCATE_PHYSICAL_HANDLER: RPCHandler<ControllerState> =
+pub(crate) const REQUEST_CORE_HANDLER: RPCHandler = processops::request_core::handle_request_core;
+pub(crate) const ALLOCATE_PHYSICAL_HANDLER: RPCHandler =
     processops::allocate_physical::handle_allocate_physical;
-pub(crate) const RELEASE_PHYSICAL_HANDLER: RPCHandler<ControllerState> =
+pub(crate) const RELEASE_PHYSICAL_HANDLER: RPCHandler =
     processops::release_physical::handle_release_physical;
-pub(crate) const LOG_HANDLER: RPCHandler<ControllerState> = processops::print::handle_log;
+pub(crate) const LOG_HANDLER: RPCHandler = processops::print::handle_log;
 
 // Re-export handlers: system operations
-pub(crate) const GET_HARDWARE_THREADS_HANDLER: RPCHandler<ControllerState> =
+pub(crate) const GET_HARDWARE_THREADS_HANDLER: RPCHandler =
     systemops::get_hardware_threads::handle_get_hardware_threads;
 
 // there aren't syscalls, but are other operations
-pub(crate) const GET_SHMEM_STRUCTURE_HANDLER: RPCHandler<ControllerState> =
+pub(crate) const GET_SHMEM_STRUCTURE_HANDLER: RPCHandler =
     get_shmem_structure::handle_get_shmem_structure;
-pub(crate) const GET_SHMEM_FRAMES_HANDLER: RPCHandler<ControllerState> =
-    get_shmem_frames::handle_get_shmem_frames;
+pub(crate) const GET_SHMEM_FRAMES_HANDLER: RPCHandler = get_shmem_frames::handle_get_shmem_frames;
 
 /// A cache of base pages
 /// TODO(rackscale): think about how we should constrain this?

--- a/kernel/src/arch/x86_64/rackscale/processops/print.rs
+++ b/kernel/src/arch/x86_64/rackscale/processops/print.rs
@@ -12,7 +12,6 @@ use kpi::system::MachineId;
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
 use super::super::kernelrpc::*;
 use super::super::CLIENT_STATE;
 use crate::arch::serial::SerialControl;
@@ -60,11 +59,7 @@ pub(crate) fn rpc_log(msg: String) -> KResult<(u64, u64)> {
 }
 
 // RPC Handler function for log() RPCs in the controller
-pub(crate) fn handle_log(
-    hdr: &mut RPCHeader,
-    mut payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+pub(crate) fn handle_log(hdr: &mut RPCHeader, mut payload: &mut [u8]) -> Result<(), RPCError> {
     // Decode and return the result
     if let Some((res, remaining)) = unsafe { decode::<LogReq>(&mut payload) } {
         match core::str::from_utf8(
@@ -80,5 +75,5 @@ pub(crate) fn handle_log(
 
     // Construct results from return data
     construct_ret(hdr, payload, Ok((0, 0)));
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/arch/x86_64/rackscale/processops/print.rs
+++ b/kernel/src/arch/x86_64/rackscale/processops/print.rs
@@ -65,7 +65,7 @@ pub(crate) fn handle_log(hdr: &mut RPCHeader, mut payload: &mut [u8]) -> Result<
         match core::str::from_utf8(
             &remaining[0..(hdr.msg_len as usize - core::mem::size_of::<LogReq>())],
         ) {
-            Ok(msg_str) => sprint!("RemoteLog({}) {}", res.mid, msg_str),
+            Ok(msg_str) => log::info!("RemoteLog({}) {}", res.mid, msg_str),
             Err(e) => log::error!(
                 "log: invalid UTF-8 string: {:?}",
                 &payload[0..hdr.msg_len as usize]

--- a/kernel/src/arch/x86_64/rackscale/registration.rs
+++ b/kernel/src/arch/x86_64/rackscale/registration.rs
@@ -133,7 +133,7 @@ pub(crate) fn register_client(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result
 
         // Register client resources with DCM
         if dcm_register_node(req.mid, req.num_cores, memslices) {
-            log::info!("Registered client DCM");
+            log::info!("Registered client with DCM");
         } else {
             log::error!("Failed to register client with DCM");
             return Err(RPCError::RegistrationError);

--- a/kernel/src/arch/x86_64/rackscale/syscalls.rs
+++ b/kernel/src/arch/x86_64/rackscale/syscalls.rs
@@ -67,8 +67,7 @@ impl VSpaceDispatch<u64> for Arch86LwkSystemCall {
         let mut total_len = 0;
 
         if total_needed_base_pages > 0 {
-            let mut bp_cache = CLIENT_STATE.per_process_base_pages.lock();
-            let mut per_process_bp_cache = &mut bp_cache[pid];
+            let mut per_process_bp_cache = CLIENT_STATE.per_process_base_pages[pid].lock();
             let base_pages_from_cache = core::cmp::min(
                 per_process_bp_cache.free_base_pages(),
                 total_needed_base_pages,
@@ -127,8 +126,7 @@ impl VSpaceDispatch<u64> for Arch86LwkSystemCall {
                 }
 
                 // Add any remaining base pages to the cache, if there's space.
-                let mut bp_cache = CLIENT_STATE.per_process_base_pages.lock();
-                let mut per_process_bp_cache = &mut bp_cache[pid];
+                let mut per_process_bp_cache = CLIENT_STATE.per_process_base_pages[pid].lock();
                 let base_pages_to_save = core::cmp::min(
                     base_page_iter.len(),
                     per_process_bp_cache.spare_base_page_capacity(),

--- a/kernel/src/arch/x86_64/rackscale/systemops/get_hardware_threads.rs
+++ b/kernel/src/arch/x86_64/rackscale/systemops/get_hardware_threads.rs
@@ -12,7 +12,7 @@ use kpi::system::CpuThread;
 use rpc::rpc::*;
 use rpc::RPCClient;
 
-use super::super::controller_state::ControllerState;
+use super::super::controller_state::CONTROLLER_STATE;
 use super::super::kernelrpc::*;
 use crate::arch::process::Ring3Process;
 use crate::arch::rackscale::CLIENT_STATE;
@@ -71,10 +71,9 @@ pub(crate) fn rpc_get_hardware_threads(
 pub(crate) fn handle_get_hardware_threads(
     hdr: &mut RPCHeader,
     payload: &mut [u8],
-    state: ControllerState,
-) -> Result<ControllerState, RPCError> {
+) -> Result<(), RPCError> {
     // Encode hwthread information into payload buffer
-    let hw_threads = state.get_hardware_threads();
+    let hw_threads = CONTROLLER_STATE.get_hardware_threads();
     let start = KernelRpcRes_SIZE as usize;
     let end = start
         + hw_threads.len() * core::mem::size_of::<CpuThread>()
@@ -95,5 +94,5 @@ pub(crate) fn handle_get_hardware_threads(
         Ok((additional_data as u64, 0)),
         additional_data as u64,
     );
-    Ok(state)
+    Ok(())
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -119,11 +119,11 @@ pub(crate) fn main() {
         .get()
         .map_or(false, |c| c.mode == cmdline::Mode::Controller)
     {
-        arch::rackscale::controller::run();
-    } else if *crate::environment::MACHINE_ID != 1 {
+        arch::rackscale::controller::poll_interface();
+    } else if *environment::MACHINE_ID != 1 {
         // For clients other than client 1, just wait for work.
         log::debug!("Waiting for work!");
-        crate::scheduler::schedule()
+        scheduler::schedule()
     }
 
     #[cfg(not(feature = "integration-test"))]
@@ -132,7 +132,7 @@ pub(crate) fn main() {
         if let Err(e) = ret {
             log::warn!("{}", e);
         }
-        crate::scheduler::schedule()
+        scheduler::schedule()
     }
     #[cfg(feature = "integration-test")]
     {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -122,7 +122,7 @@ pub(crate) fn main() {
         arch::rackscale::controller::run();
     } else if *crate::environment::MACHINE_ID != 1 {
         // For clients other than client 1, just wait for work.
-        log::info!("Waiting for work!");
+        log::debug!("Waiting for work!");
         crate::scheduler::schedule()
     }
 

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -354,12 +354,11 @@ impl KernelAllocator {
 
         // Take base pages from caches is possible
         if total_needed_base_pages > 0 || is_local_controller {
-            let mut manager_list = if is_controller {
-                CONTROLLER_SHMEM_CACHES.lock()
+            let mut cache_manager = if is_controller {
+                CONTROLLER_SHMEM_CACHES[affinity_index].lock()
             } else {
-                CLIENT_STATE.affinity_base_pages.lock()
+                CLIENT_STATE.affinity_base_pages[affinity_index].lock()
             };
-            let cache_manager = &mut manager_list[affinity_index];
             let pcm = try_per_core_mem().ok_or(KError::KcbUnavailable)?;
             let mut mem_manager = pcm.try_mem_manager()?;
 
@@ -450,12 +449,11 @@ impl KernelAllocator {
             }
 
             // Add any remaining base pages to the cache, if there's space.
-            let mut manager_list = if is_controller {
-                CONTROLLER_SHMEM_CACHES.lock()
+            let mut cache_manager = if is_controller {
+                CONTROLLER_SHMEM_CACHES[affinity_index].lock()
             } else {
-                CLIENT_STATE.affinity_base_pages.lock()
+                CLIENT_STATE.affinity_base_pages[affinity_index].lock()
             };
-            let cache_manager = &mut manager_list[affinity_index];
             let base_pages_to_save = core::cmp::min(
                 base_page_iter.len(),
                 cache_manager.spare_base_page_capacity(),

--- a/kernel/src/memory/vspace.rs
+++ b/kernel/src/memory/vspace.rs
@@ -76,7 +76,7 @@ impl CoreBitMap {
     }
 }
 
-pub(crate) struct CoreBitMapIter(CoreBitMap);
+pub(crate) struct CoreBitMapIter(pub(crate) CoreBitMap);
 
 impl Iterator for CoreBitMapIter {
     type Item = usize;

--- a/kernel/src/transport/ethernet.rs
+++ b/kernel/src/transport/ethernet.rs
@@ -97,17 +97,17 @@ pub(crate) fn init_ethernet_rpc(
     server_ip: smoltcp::wire::IpAddress,
     server_port: u16,
     send_client_data: bool, // This field is used to indicate if init_client() should send ClientRegistrationRequest
-) -> KResult<alloc::boxed::Box<rpc::client::Client>> {
+) -> KResult<rpc::client::Client> {
     use crate::arch::rackscale::registration::initialize_client;
     use alloc::boxed::Box;
     use rpc::client::Client;
     use rpc::transport::TCPTransport;
     use rpc::RPCClient;
 
-    let rpc_transport = Box::try_new(
+    let rpc_transport = Box::new(
         TCPTransport::new(Some(server_ip), server_port, Arc::clone(&ETHERNET_IFACE))
             .map_err(|err| KError::RackscaleRPCError { err })?,
-    )?;
-    let mut client = Box::try_new(Client::new(rpc_transport))?;
+    );
+    let mut client = Client::new(rpc_transport);
     initialize_client(client, send_client_data)
 }

--- a/kernel/src/transport/shmem.rs
+++ b/kernel/src/transport/shmem.rs
@@ -208,7 +208,7 @@ impl ShmemDevice {
         let doorbell = *self.doorbell.lock();
         let doorbell_ptr = doorbell as *mut u32;
         unsafe { core::ptr::write(doorbell_ptr, doorbell_value) };
-        log::info!(
+        log::debug!(
             "doorbell set to: {:#032b} (id={:#016b}, vector={:#016b})",
             doorbell_value,
             id,
@@ -234,7 +234,7 @@ impl ShmemDevice {
         log::debug!("MSI-X table {:?}", tbl_paddr);
         assert!(table_vector < tbl_paddr.len());
 
-        log::info!(
+        log::debug!(
             "Original MSI entry {:?} is {:?}",
             table_vector,
             tbl_paddr[table_vector]
@@ -294,7 +294,7 @@ impl ShmemDevice {
         // Toggle the interrupt mask for this vector
         tbl_paddr[table_vector].vector_control ^= 0x1;
 
-        log::info!(
+        log::debug!(
             "New MSI entry {:?} is {:?}",
             table_vector,
             tbl_paddr[table_vector]

--- a/kernel/src/transport/shmem.rs
+++ b/kernel/src/transport/shmem.rs
@@ -367,7 +367,7 @@ pub(crate) fn create_shmem_transport(mid: MachineId) -> KResult<ShmemTransport<'
 #[cfg(feature = "rpc")]
 pub(crate) fn init_shmem_rpc(
     send_client_data: bool, // This field is used to indicate if init_client() should send ClientRegistrationRequest
-) -> KResult<Box<rpc::client::Client>> {
+) -> KResult<rpc::client::Client> {
     use crate::arch::rackscale::registration::initialize_client;
     use rpc::client::Client;
 
@@ -375,7 +375,7 @@ pub(crate) fn init_shmem_rpc(
     let transport = Box::try_new(create_shmem_transport(*crate::environment::MACHINE_ID)?)?;
 
     // Create the client
-    let client = Box::try_new(Client::new(transport))?;
+    let client = Client::new(transport);
     initialize_client(client, send_client_data)
 }
 

--- a/kernel/testutils/src/rackscale_runner.rs
+++ b/kernel/testutils/src/rackscale_runner.rs
@@ -128,7 +128,7 @@ impl<T: Clone + Send + 'static> RackscaleRun<T> {
             file_name: "".to_string(),
             cmd: "".to_string(),
             arg: None,
-            client_build_delay: 5_000, // 5 seconds
+            client_build_delay: 6_000, // 5 seconds
             run_dhcpd_for_baseline: false,
         }
     }

--- a/lib/rpc/src/api.rs
+++ b/lib/rpc/src/api.rs
@@ -6,33 +6,31 @@ use core::result::Result;
 use crate::rpc::{RPCError, RPCHeader, RPCType};
 
 /// RPC Handler function
-pub type RPCHandler<S> =
-    fn(hdr: &mut RPCHeader, payload: &mut [u8], state: S) -> Result<S, RPCError>;
+pub type RPCHandler = fn(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError>;
 
 /// RPC Client registration function
-pub type RegistrationHandler<S> =
-    fn(hdr: &mut RPCHeader, payload: &mut [u8], state: S) -> Result<S, RPCError>;
+pub type RegistrationHandler = fn(hdr: &mut RPCHeader, payload: &mut [u8]) -> Result<(), RPCError>;
 
 /// RPC server operations
-pub trait RPCServer<'a, S> {
+pub trait RPCServer<'a> {
     /// Register an RPC func with an ID
-    fn register<'c>(&mut self, rpc_id: RPCType, handler: &'c RPCHandler<S>) -> Result<(), RPCError>
+    fn register<'c>(&mut self, rpc_id: RPCType, handler: &'c RPCHandler) -> Result<(), RPCError>
     where
         'c: 'a;
 
     /// Accept an RPC client
-    fn add_client<'c>(&mut self, func: &'c RegistrationHandler<S>, state: S) -> Result<S, RPCError>
+    fn add_client<'c>(&mut self, func: &'c RegistrationHandler) -> Result<(), RPCError>
     where
         'c: 'a;
 
     /// Handle 1 RPC per client
-    fn handle(&self, state: S) -> Result<S, RPCError>;
+    fn handle(&mut self) -> Result<(), RPCError>;
 
     /// Try to handle 1 RPC per client, if data is available (non-blocking if RPCs not available)
-    fn try_handle(&self, state: S) -> Result<(S, bool), RPCError>;
+    fn try_handle(&mut self) -> Result<bool, RPCError>;
 
     /// Run the RPC server
-    fn run_server(&self, state: S) -> Result<S, RPCError>;
+    fn run_server(&mut self) -> Result<(), RPCError>;
 }
 
 /// RPC client operations

--- a/lib/rpc/src/rpc.rs
+++ b/lib/rpc/src/rpc.rs
@@ -39,6 +39,7 @@ pub const HDR_LEN: usize = core::mem::size_of::<RPCHeader>();
 impl RPCHeader {
     /// # Safety
     /// - `self` must be valid RPCHeader
+    #[inline(always)]
     pub unsafe fn as_mut_bytes(&mut self) -> &mut [u8; HDR_LEN] {
         ::core::slice::from_raw_parts_mut((self as *const RPCHeader) as *mut u8, HDR_LEN)
             .try_into()
@@ -47,6 +48,7 @@ impl RPCHeader {
 
     /// # Safety
     /// - `self` must be valid RPCHeader
+    #[inline(always)]
     pub unsafe fn as_bytes(&self) -> &[u8; HDR_LEN] {
         ::core::slice::from_raw_parts((self as *const RPCHeader) as *const u8, HDR_LEN)
             .try_into()
@@ -74,6 +76,7 @@ impl Default for MBuf {
 impl MBuf {
     /// # Safety
     /// - `self` must be valid RPCHeader
+    #[inline(always)]
     pub unsafe fn as_mut_bytes(&mut self) -> &mut [u8; MAX_BUFF_LEN] {
         ::core::slice::from_raw_parts_mut((self as *const MBuf) as *mut u8, MAX_BUFF_LEN)
             .try_into()
@@ -82,6 +85,7 @@ impl MBuf {
 
     /// # Safety
     /// - `self` must be valid RPCHeader
+    #[inline(always)]
     pub unsafe fn as_bytes(&self) -> &[u8; MAX_BUFF_LEN] {
         ::core::slice::from_raw_parts((self as *const MBuf) as *const u8, MAX_BUFF_LEN)
             .try_into()

--- a/lib/rpc/src/transport/shmem/mod.rs
+++ b/lib/rpc/src/transport/shmem/mod.rs
@@ -21,15 +21,18 @@ impl<'a> Sender<'a> {
         ))
     }
 
+    #[inline(always)]
     pub fn with_shared_queue(q: Arc<Queue<'a>>) -> Sender<'a> {
         Sender(q.clone())
     }
 
+    #[inline(always)]
     pub fn send(&self, data: &[&[u8]]) -> bool {
         while !self.0.enqueue(data) {}
         true
     }
 
+    #[inline(always)]
     pub fn try_send(&self, data: &[&[u8]]) -> bool {
         self.0.enqueue(data)
     }
@@ -48,10 +51,12 @@ impl<'a> Receiver<'a> {
         ))
     }
 
+    #[inline(always)]
     pub fn with_shared_queue(q: Arc<Queue<'a>>) -> Receiver<'a> {
         Receiver(q.clone())
     }
 
+    #[inline(always)]
     pub fn recv(&self, data_out: &mut [&mut [u8]]) -> usize {
         loop {
             let ret = self.0.dequeue(data_out);
@@ -61,6 +66,7 @@ impl<'a> Receiver<'a> {
         }
     }
 
+    #[inline(always)]
     pub fn try_recv(&self, data_out: &mut [&mut [u8]]) -> Result<usize, QueueError> {
         self.0.dequeue(data_out)
     }

--- a/lib/rpc/src/transport/shmem/queue_mpmc.rs
+++ b/lib/rpc/src/transport/shmem/queue_mpmc.rs
@@ -140,10 +140,12 @@ impl<'a> State<'a> {
         )
     }
 
+    #[inline(always)]
     fn enqueue_pos(&self, ordering: Ordering) -> usize {
         unsafe { (*self.enqueue_pos).load(ordering) }
     }
 
+    #[inline(always)]
     fn dequeue_pos(&self, ordering: Ordering) -> usize {
         unsafe { (*self.dequeue_pos).load(ordering) }
     }
@@ -255,6 +257,7 @@ impl<'a> State<'a> {
         }
     }
 
+    #[inline(always)]
     unsafe fn len(&self) -> usize {
         let dequeue = self.dequeue_pos(Relaxed);
         let enqueue = self.enqueue_pos(Relaxed);
@@ -292,18 +295,22 @@ impl<'a> Queue<'a> {
         })
     }
 
+    #[inline(always)]
     pub fn enqueue(&self, values: &[&[u8]]) -> bool {
         unsafe { self.state.push(values) }
     }
 
+    #[inline(always)]
     pub fn dequeue(&self, values: &mut [&mut [u8]]) -> Result<usize, QueueError> {
         unsafe { self.state.pop(values) }
     }
 
+    #[inline(always)]
     pub fn len(&self) -> usize {
         unsafe { self.state.len() }
     }
 
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         unsafe { self.state.len() == 0 }
     }

--- a/lib/rpc/src/transport/shmem/transport.rs
+++ b/lib/rpc/src/transport/shmem/transport.rs
@@ -19,6 +19,7 @@ impl<'a> ShmemTransport<'a> {
         ShmemTransport { rx, tx }
     }
 
+    #[inline(always)]
     fn send(&self, buf: &[u8]) -> Result<(), RPCError> {
         match self.tx.send(&[buf]) {
             true => Ok(()),
@@ -26,15 +27,18 @@ impl<'a> ShmemTransport<'a> {
         }
     }
 
+    #[inline(always)]
     fn try_send(&self, buf: &[u8]) -> Result<bool, RPCError> {
         Ok(self.tx.try_send(&[buf]))
     }
 
+    #[inline(always)]
     fn recv(&self, buf: &mut [u8]) -> Result<(), RPCError> {
         self.rx.recv(&mut [buf]);
         Ok(())
     }
 
+    #[inline(always)]
     fn try_recv(&self, buf: &mut [u8]) -> Result<bool, RPCError> {
         match self.rx.try_recv(&mut [buf]) {
             Ok(_) => Ok(true),

--- a/lib/rpc/tests/integration-test.rs
+++ b/lib/rpc/tests/integration-test.rs
@@ -4,6 +4,7 @@
 #[test]
 fn test_client_server_shmem_transport() {
     use std::alloc::{alloc, Layout};
+    use std::boxed::Box;
     use std::sync::Arc;
     use std::thread;
 
@@ -36,29 +37,21 @@ fn test_client_server_shmem_transport() {
         let mut server = Server::new(rpc_server_transport);
 
         // Register an echo RPC
-        fn echo_rpc_handler(
-            _hdr: &mut RPCHeader,
-            _payload: &mut [u8],
-            _state: (),
-        ) -> Result<(), RPCError> {
+        fn echo_rpc_handler(_hdr: &mut RPCHeader, _payload: &mut [u8]) -> Result<(), RPCError> {
             Ok(())
         }
-        const ECHO_HANDLER: RPCHandler<()> = echo_rpc_handler;
+        const ECHO_HANDLER: RPCHandler = echo_rpc_handler;
         server.register(RPC_ECHO, &ECHO_HANDLER).unwrap();
 
         // Accept a client
-        fn register_client(
-            _hdr: &mut RPCHeader,
-            _payload: &mut [u8],
-            _state: (),
-        ) -> Result<(), RPCError> {
+        fn register_client(_hdr: &mut RPCHeader, _payload: &mut [u8]) -> Result<(), RPCError> {
             Ok(())
         }
-        pub const CLIENT_REGISTRAR: RegistrationHandler<()> = register_client;
-        server.add_client(&CLIENT_REGISTRAR, ()).unwrap();
+        pub const CLIENT_REGISTRAR: RegistrationHandler = register_client;
+        server.add_client(&CLIENT_REGISTRAR).unwrap();
 
         // Run the server
-        server.run_server(()).unwrap();
+        server.run_server().unwrap();
     });
 
     // Create a client
@@ -118,29 +111,21 @@ fn test_client_shmem_multithread() {
         let mut server = Server::new(rpc_server_transport);
 
         // Register an echo RPC
-        fn echo_rpc_handler(
-            _hdr: &mut RPCHeader,
-            _payload: &mut [u8],
-            _state: (),
-        ) -> Result<(), RPCError> {
+        fn echo_rpc_handler(_hdr: &mut RPCHeader, _payload: &mut [u8]) -> Result<(), RPCError> {
             Ok(())
         }
-        const ECHO_HANDLER: RPCHandler<()> = echo_rpc_handler;
+        const ECHO_HANDLER: RPCHandler = echo_rpc_handler;
         server.register(RPC_ECHO, &ECHO_HANDLER).unwrap();
 
         // Accept a client
-        fn register_client(
-            _hdr: &mut RPCHeader,
-            _payload: &mut [u8],
-            _state: (),
-        ) -> Result<(), RPCError> {
+        fn register_client(_hdr: &mut RPCHeader, _payload: &mut [u8]) -> Result<(), RPCError> {
             Ok(())
         }
-        pub const CLIENT_REGISTRAR: RegistrationHandler<()> = register_client;
-        server.add_client(&CLIENT_REGISTRAR, ()).unwrap();
+        pub const CLIENT_REGISTRAR: RegistrationHandler = register_client;
+        server.add_client(&CLIENT_REGISTRAR).unwrap();
 
         // Run the server
-        server.run_server(()).unwrap();
+        server.run_server().unwrap();
     });
 
     // Create a client


### PR DESCRIPTION
This PR includes code to simplify the RPC library code, use fine-grained locks (mutexes) in controller and client data structures, and to make the controller multi-threaded.

Previously, even single-core RPCs suffered latency problems becasue the controller is single-core. Even using the shmem RPC transport between the client and the controller, since the controller uses TCP to communicate with DCM, the controller had to poll the ethernet interface between RPC calls which reduced RPC throughput.

Now, the controller uses n + 1 cores, where n is the number of clients. The extra core is used to poll the ethernet interface and to check for RPCs send from DCM. To make this work, I had to re-architect how resource responses are received from the DCM scheduler.

### Previously:
The controller held a global client and RPC server (and DCM likewise has an RPC server and an RPC client).
The controller DCM client was used to send resource allocation adn release requests. Release requests are handled immediately, but allocation requests return with just an allocation id.

When the DCM scheduler then actually solves the allocation request, it sends the assigned node as an RPC to the controller RPC server. In the single-threaded controller, it could safely be assumed that the RPC server would receive responses only for a specific set of allocations requests, since there coudl only be one outstanding request at a time. Once the controller become muti-core, this is no longer true.

### Now:
Core 0 on the controller has a local copy of the DCM RPC server, while the DCM RPC client is still global. When a client needs to make a request of DCM, it sends an RPC to the controller which is handled by core n where n corresponds to the client number. On response, the client then inserts the allocation IDs into a hashmap with a pointer to an atomic bool set to false. The client then polls on the atomic bool (as opposed to the hash table).

On core 0 on the controller, this core loops while polling the ethernet interface and checking for RPCs from DCM. If it receives an allocation assignment, it updatees the hashmap entry for the allocation ID with the assigned node Id, and then sets the atomic bool to true. In this way, the controller can handle multiple asynchronous resource allocation requests to DCM at a time.

Even for single core, this results in a 2x improvment in RPC throughput.

General global state in rackscale, to be reviewed for scalability/suitability are in the files:
* [controller_state.rs](https://github.com/vmware-labs/node-replicated-kernel/blob/dev/rackscale-rpcs/kernel/src/arch/x86_64/rackscale/controller_state.rs)
* [client_state.rs](https://github.com/vmware-labs/node-replicated-kernel/blob/dev/rackscale-rpcs/kernel/src/arch/x86_64/rackscale/client_state.rs)
* [dcm/mod.rs](https://github.com/vmware-labs/node-replicated-kernel/blob/dev/rackscale-rpcs/kernel/src/arch/x86_64/rackscale/dcm/mod.rs)