### PR TITLE
Set numa memory affinity in run.py even for single core qemu instances

### DIFF
--- a/kernel/run.py
+++ b/kernel/run.py
@@ -453,7 +453,7 @@ def run_qemu(args):
     num_host_numa_nodes = len(host_numa_nodes_list)
     if args.qemu_nodes and args.qemu_nodes > 0:
         for node in range(0, args.qemu_nodes):
-            if args.qemu_cores > 1:
+            if args.qemu_cores > 0:
                 offset = args.qemu_node_offset if args.qemu_node_offset else 0
                 mem_per_node = args.qemu_memory / args.qemu_nodes
                 prealloc = "on" if args.qemu_prealloc else "off"

--- a/kernel/tests/s10_benchmarks.rs
+++ b/kernel/tests/s10_benchmarks.rs
@@ -223,12 +223,13 @@ fn s10_shootdown_simple() {
             cmdline = cmdline.memory(48 * 1024);
         }
 
-        if cfg!(feature = "smoke") && cores > 2 {
-            cmdline = cmdline.nodes(2);
+        let num_nodes = if cfg!(feature = "smoke") && cores > 2 {
+            core::cmp::min(cores, 2)
         } else {
             let max_numa_nodes = cmdline.machine.max_numa_nodes();
-            cmdline = cmdline.nodes(max_numa_nodes);
-        }
+            core::cmp::min(cores, max_numa_nodes)
+        };
+        cmdline = cmdline.nodes(num_nodes);
 
         let mut output = String::new();
         let mut qemu_run = || -> Result<WaitStatus> {

--- a/kernel/tests/s11_rackscale_benchmarks.rs
+++ b/kernel/tests/s11_rackscale_benchmarks.rs
@@ -432,7 +432,7 @@ fn s11_rackscale_shmem_leveldb_benchmark() {
     }
 
     fn rackscale_timeout_fn(num_cores: usize) -> u64 {
-        180_000 + 500 * num_cores as u64
+        240_000 + 500 * num_cores as u64
     }
 
     fn mem_fn(num_cores: usize, is_smoke: bool) -> usize {

--- a/kernel/tests/s11_rackscale_benchmarks.rs
+++ b/kernel/tests/s11_rackscale_benchmarks.rs
@@ -26,6 +26,7 @@ fn s11_rackscale_shmem_fxmark_benchmark() {
 }
 
 #[test]
+#[ignore]
 #[cfg(not(feature = "baremetal"))]
 fn s11_rackscale_ethernet_fxmark_benchmark() {
     rackscale_fxmark_benchmark(RackscaleTransport::Ethernet);


### PR DESCRIPTION
Curently, run.py doesn't assign memory with a specific numa affinity if there is only one core. I think this makes sense for NrOS, because based on the host policy it is likely that the memory allocated will have a matching affinity with the core.

However, for rackscale, it does not make as much sense because - even when running a client with 1 core - as we may be running two clients with 1 core each and we'll want to make sure they use resources from different host numa nodes.