### PR TITLE
Rkapp/memcached bench skylake4x

### DIFF
--- a/kernel/tests/s11_rackscale_benchmarks.rs
+++ b/kernel/tests/s11_rackscale_benchmarks.rs
@@ -627,7 +627,7 @@ fn rackscale_memcached_benchmark(transport: RackscaleTransport) {
     }
 
     fn rackscale_timeout_fn(num_cores: usize) -> u64 {
-        180_000 + 2_000 * num_cores as u64
+        240_000 + 5_000 * num_cores as u64
     }
 
     fn mem_fn(num_cores: usize, is_smoke: bool) -> usize {

--- a/kernel/tests/s11_rackscale_benchmarks.rs
+++ b/kernel/tests/s11_rackscale_benchmarks.rs
@@ -627,7 +627,7 @@ fn rackscale_memcached_benchmark(transport: RackscaleTransport) {
     }
 
     fn rackscale_timeout_fn(num_cores: usize) -> u64 {
-        180_000 + 1_500 * num_cores as u64
+        180_000 + 2_000 * num_cores as u64
     }
 
     fn mem_fn(num_cores: usize, is_smoke: bool) -> usize {

--- a/usr/rkapps/build.rs
+++ b/usr/rkapps/build.rs
@@ -138,11 +138,11 @@ fn main() {
             .unwrap();
 
         println!(
-            "CHECKOUT 45855aaa1ba403daa53d470626e56131ff505a34 {:?}",
+            "CHECKOUT be303d8bfc2c40d63704848bb3acd9e075dd61e4 {:?}",
             out_dir
         );
         Command::new("git")
-            .args(&["checkout", "45855aaa1ba403daa53d470626e56131ff505a34"])
+            .args(&["checkout", "be303d8bfc2c40d63704848bb3acd9e075dd61e4"])
             .current_dir(&Path::new(&out_dir))
             .status()
             .unwrap();


### PR DESCRIPTION
Rackscale memcached wasn't passing for skylake4x. This PR changes the memcached rkapps commit and increases the test timeout.