### PR TITLE
Handle cmdline parsing errors

### DIFF
--- a/kernel/src/arch/x86_64/mod.rs
+++ b/kernel/src/arch/x86_64/mod.rs
@@ -249,6 +249,7 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
 
     // Very early init:
     sprint!("\r\n");
+    sprint!("NRK booting on x86_64...\r\n");
     enable_sse();
     enable_fsgsbase();
     unsafe {
@@ -276,7 +277,14 @@ fn _start(argc: isize, _argv: *const *const u8) -> isize {
         //   memory for us
         unsafe { transmute::<u64, &'static KernelArgs>(argc as u64) };
     // Parse the command line arguments:
-    let cmdline = CommandLineArguments::from_str(kernel_args.command_line);
+    let cmdline = match CommandLineArguments::from_str(kernel_args.command_line) {
+        Ok(cmdline) => cmdline,
+        Err(err) => {
+            sprint!("Parsing the commandline failed ({err}). Halting...\r\n");
+            halt();
+        }
+    };
+
     // Initialize cmdline arguments as global
     crate::CMDLINE.call_once(move || cmdline);
     // Initialize kernel arguments as global

--- a/kernel/src/cmdline.rs
+++ b/kernel/src/cmdline.rs
@@ -232,8 +232,14 @@ impl CommandLineArguments {
                         && prev != CmdToken::Test
                         && prev != CmdToken::MachineId
                         && prev != CmdToken::Workers
+                        && prev != CmdToken::Mode
+                        && prev != CmdToken::Transport
                     {
-                        sprint!("Malformed args (unexpected equal sign) in {}\r\n", args);
+                        sprint!(
+                            "Malformed args (unexpected equal sign) in `{}` previous token was {:?}\r\n",
+                            args,
+                            prev
+                        );
                         return Err(KError::MalformedCmdLine);
                     }
                 }

--- a/kernel/src/cmdline.rs
+++ b/kernel/src/cmdline.rs
@@ -315,7 +315,7 @@ mod test {
 
     #[test]
     fn parse_args_empty() {
-        let ba = CommandLineArguments::from_str("");
+        let ba = CommandLineArguments::from_str("").expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "info");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "");
@@ -323,7 +323,7 @@ mod test {
 
     #[test]
     fn parse_args_nrk() {
-        let ba = CommandLineArguments::from_str("./nrk");
+        let ba = CommandLineArguments::from_str("./nrk").expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "info");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "");
@@ -331,7 +331,7 @@ mod test {
 
     #[test]
     fn parse_args_basic() {
-        let ba = CommandLineArguments::from_str("./kernel");
+        let ba = CommandLineArguments::from_str("./kernel").expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "info");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "");
@@ -339,7 +339,8 @@ mod test {
 
     #[test]
     fn parse_args_log() {
-        let ba = CommandLineArguments::from_str("./kernel log=error");
+        let ba =
+            CommandLineArguments::from_str("./kernel log=error").expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "error");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "");
@@ -347,7 +348,8 @@ mod test {
 
     #[test]
     fn parse_args_init() {
-        let ba = CommandLineArguments::from_str("./kernel init=file log=trace");
+        let ba = CommandLineArguments::from_str("./kernel init=file log=trace")
+            .expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "trace");
         assert_eq!(ba.init_binary, "file");
         assert_eq!(ba.init_args, "");
@@ -355,7 +357,8 @@ mod test {
 
     #[test]
     fn parse_args_initargs() {
-        let ba = CommandLineArguments::from_str("./kernel initargs=0");
+        let ba =
+            CommandLineArguments::from_str("./kernel initargs=0").expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "info");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "0");
@@ -365,7 +368,7 @@ mod test {
     fn parse_args_leveldb() {
         let args = "./kernel log=warn init=dbbench.bin initargs=3 appcmd='--threads=1 --benchmarks=fillseq,readrandom --reads=100000 --num=50000 --value_size=65535'";
 
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "warn");
         assert_eq!(ba.init_binary, "dbbench.bin");
         assert_eq!(ba.init_args, "3");
@@ -375,7 +378,7 @@ mod test {
     #[test]
     fn parse_args_fxmark() {
         let args = "log=debug initargs=1X1XmixX0";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "debug");
         assert_eq!(ba.init_binary, "init");
         assert_eq!(ba.init_args, "1X1XmixX0");
@@ -384,7 +387,7 @@ mod test {
     #[test]
     fn parse_args_empty_literal_quotes() {
         let args = "./kernel initargs='\"\"' log=debug";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "debug");
         assert_eq!(ba.init_args, "\"\"");
     }
@@ -392,7 +395,7 @@ mod test {
     #[test]
     fn parse_args_empty_literal() {
         let args = "./kernel initargs='' log=debug";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "debug");
         assert_eq!(ba.init_args, "");
     }
@@ -401,14 +404,13 @@ mod test {
     fn parse_args_invalid() {
         let args = "./kernel initg='asdf' log=debug";
         let ba = CommandLineArguments::from_str(args);
-        assert_eq!(ba.log_filter, "debug");
-        assert_eq!(ba.init_args, "");
+        assert!(ba.is_err());
     }
 
     #[test]
     fn parse_args_invalid2() {
         let args = "./sadf init='asdf' log=debug";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "debug");
         assert_eq!(ba.init_args, "");
     }
@@ -417,51 +419,50 @@ mod test {
     fn parse_args_invalid3() {
         let args = "./kernel init=---  as-s- log=debug";
         let ba = CommandLineArguments::from_str(args);
-        assert_eq!(ba.log_filter, "debug");
-        assert_eq!(ba.init_args, "");
+        assert!(ba.is_err());
     }
 
     #[test]
     fn parse_log_level_complex() {
         let args = "./kernel log='gdbstub=trace,nrk::arch::gdb=trace'";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.log_filter, "gdbstub=trace,nrk::arch::gdb=trace");
     }
 
     #[test]
     fn parse_test() {
         let args = "./kernel test=userspace";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.test, Some("userspace"));
     }
 
     #[test]
     fn parse_machine_id() {
         let args = "./kernel mid=3";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.machine_id, 3);
 
         let args = "./kernel mid='44'";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.machine_id, 44);
 
         let args = "./kernel mid=a";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.machine_id, 0);
     }
 
     #[test]
     fn parse_workers() {
         let args = "./kernel workers=3";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.workers, 3);
 
         let args = "./kernel workers='44'";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.workers, 44);
 
         let args = "./kernel workers=a";
-        let ba = CommandLineArguments::from_str(args);
+        let ba = CommandLineArguments::from_str(args).expect("failed to parse cmdline");
         assert_eq!(ba.workers, 1);
     }
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -173,6 +173,10 @@ pub enum KError {
     TryFromIntError,
     /// The provided file-descriptor value was too big (>= MAX_FILES_PER_PROCESS)
     FileDescriptorTooLarge,
+    /// The command line was malformed
+    MalformedCmdLine,
+    /// The command line had invalid option configurations
+    InvalidCmdLineOptions,
     /// Rackscale: Unable to convert message ID to valid RPC type (faulty message?)
     InvalidRpcType,
     /// Rackscale: Unable to perform DCM transaction (faulty message?)

--- a/lib/vmxnet3/src/var.rs
+++ b/lib/vmxnet3/src/var.rs
@@ -877,6 +877,7 @@ impl DevQueue for RxQueue {
 
         let mut idx = self.pidx_tail0;
         let mut available = 0; // Completed descriptors
+        #[cfg(debug_assertions)]
         let mut expect_sop = true;
         let mut completed_gen = rxc.vxcr_gen;
         loop {


### PR DESCRIPTION
Depending on the commandline formatting, there was a case where this
resulted in an endless loop in processing the command line. Errors were
printed using the `error!` macro, that used the logger functionality
before it was setup.

We introduce an error return value for parsing the commandline. It
returns an error whenever there was something wrong with the command
line that could lead to a misconfiguration of the runtime parameters.
For that we have two error values:
 - InvalidCmdLineOptions indicating the command line parsed fine, but
   the selected option are not supported
 - MalformedCmdLine indicating that there were issues with parsing the
   commandline that would have led to skipped arguments.


Example output:

```
NRK booting on x86_64...
Malformed commandline! Encoutered '\' while parsing cmd args: ./kernel log=info test=userspace-smp init=memcachedbench.bin initargs=1 appcmd=\'foo mid=0
Parsing the commandline failed (The command line was malformed). Halting...
```