### PR TITLE
Fixed mdbook cargo install in build script

### DIFF
--- a/scripts/generic-setup.sh
+++ b/scripts/generic-setup.sh
@@ -75,7 +75,7 @@ function install_rust_build_dependencies()
             # otherwise this takes >5min in CI:
             MDBOOK_FLAGS="--no-default-features"
         fi
-        cargo install mdbook $MDBOOK_FLAGS
+        cargo install mdbook $MDBOOK_FLAGS --locked
     fi
 }
 


### PR DESCRIPTION
Forces cargo to use Cargo.lock when installing mdbook so that build succeeds