### PR TITLE
Lock mdbook version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
           ssh-key: ${{ secrets.WEBSITE_DEPLOY_SSH_KEY }}
       - run: |
           source ~/.cargo/env
-          cargo install mdbook --no-default-features --features search
+          cargo install mdbook --locked --no-default-features --features search
           cd doc
           mdbook build -d ../book
           cd ..


### PR DESCRIPTION
Trying to fix this issue:
```
 error: failed to compile `mdbook v0.4.35`, intermediate artifacts can be found at `/tmp/cargo-installo8ZioI`

Caused by:
  package `clap_complete v4.4.4` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.67.0-nightly
  Try re-running cargo install with `--locked`
Error: Process completed with exit code 101.
```

I tested by running just the ```cargo install``` command with/without fixes, I didn't run the whole deploy action.